### PR TITLE
Shared Zooniverse header [placeholder?]

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Header } from './Header';
+import Header from './Header';
+import ZooniverseHeader from './ZooniverseHeader';
 
 export default class App extends React.Component {
   returnSomething(something) { // eslint-disable-line class-methods-use-this
@@ -10,6 +11,7 @@ export default class App extends React.Component {
   render() {
     return (
       <div>
+        <ZooniverseHeader />
         <Header />
         {this.props.children}
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router';
 import AuthContainer from '../containers/AuthContainer';
+import { ZooniverseLogo } from 'zooniverse-react-components/lib';
 
-import AppLogo from '../images/zooniverse-icon-web-white-small.png';
-
-import { ZooniverseLogo, ZooniverseLogotype } from 'zooniverse-react-components/lib';
-
-export class Header extends React.Component {
+class Header extends React.Component {
   render() {
     return (
       <header className="app-header">        
@@ -23,3 +20,5 @@ export class Header extends React.Component {
     );
   }
 }
+
+export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,12 +4,14 @@ import AuthContainer from '../containers/AuthContainer';
 
 import AppLogo from '../images/zooniverse-icon-web-white-small.png';
 
+import { ZooniverseLogo, ZooniverseLogotype } from 'zooniverse-react-components/lib';
+
 export class Header extends React.Component {
   render() {
     return (
-      <header className="app-header">
+      <header className="app-header">        
         <Link to="/" className="app-title">
-          <img role="presentation" src={AppLogo} />
+          <ZooniverseLogo />
           <h1>Liberating the Liberator</h1>
         </Link>
         <nav>

--- a/src/components/ZooniverseHeader.jsx
+++ b/src/components/ZooniverseHeader.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router';
+import { ZooniverseLogo } from 'zooniverse-react-components/lib';
+
+class ZooniverseHeader extends React.Component {
+  render() {
+    return (
+      <div className="zooniverse-header">
+        <a className="zooniverse-main-logo" href="https://www.zooniverse.org"><ZooniverseLogo /></a>
+        <div className="zooniverse-links">
+          <a className="link" href="#" target="_blank">Projects</a>
+          <a className="link" href="#" target="_blank">About</a>
+          <a className="link" href="#" target="_blank">Get Involved</a>
+          <a className="link" href="#" target="_blank">Talk</a>
+          <a className="link" href="#" target="_blank">Build A Project</a>
+          <a className="link" href="#" target="_blank">News</a>
+        </div>
+        <div className="zooniverse-account">
+          <a className="link" href="#" target="_blank">???</a>
+          <a className="link" href="#" target="_blank">???</a>
+          <a className="link" href="#" target="_blank">???</a>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ZooniverseHeader;

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -6,7 +6,7 @@
     <title>Liberating the Liberator</title>
     <meta name="description" content="Liberating the Liberator invites volunteers to transcribe documents from the American abolitionist movement, working together with the Zooniverse community and the Boston Public Library.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans|Roboto" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/styles/components/app-header.styl
+++ b/src/styles/components/app-header.styl
@@ -8,7 +8,7 @@
   .app-title
     color: $text-color
     
-    img  //To be replaced with the proper Liberating the Liberator logo
+    svg  //To be replaced with the proper Liberating the Liberator logo
       display: inline-block
       height: 1em
       vertical-align: middle

--- a/src/styles/components/app-header.styl
+++ b/src/styles/components/app-header.styl
@@ -32,8 +32,8 @@
       margin-left: 2em
       
       &:hover
-        background: $blueberry
-        color: $light
+        background: $teal
+        color: $white
         
   .login-button, .logout-button
     font-size: 0.8em
@@ -44,13 +44,13 @@
     span
       display: inline-block
       background: $text-color
-      color: $light
+      color: $white
       padding: 0.5em 1em
       margin-right: 0.5em
       
     button
-      background: $blueberry
+      background: $teal
       border: none
       border-radius: 1em
-      color: $light
+      color: $white
       padding: 0.5em 1em

--- a/src/styles/components/zooniverse-header.styl
+++ b/src/styles/components/zooniverse-header.styl
@@ -1,0 +1,31 @@
+.zooniverse-header
+  background: $black
+  color: $pale-grey
+  display: flex
+  font-size: 0.5 * $unit-size
+  
+  a
+    color: $pale-grey
+
+  .link
+    display: inline-block
+    padding: 1em
+    text-transform: uppercase
+  
+  .zooniverse-main-logo
+    display: inline-block
+    flex: 0 0 auto
+    font-size: 0.8 * $unit-size
+    padding: 0.5em
+    vertical-align: bottom
+    
+    .zooniverse-logo
+      display: block
+    
+  .zooniverse-links
+    flex: 1 0 auto
+    display: inline-block
+    
+  .zooniverse-account
+    flex: 0 0 auto
+    display: inline-block

--- a/src/styles/global/app-theme.styl
+++ b/src/styles/global/app-theme.styl
@@ -3,12 +3,16 @@ $text-color = #5c5c5c
 $dusty-lavender = #a899a0
 $teal-blue = #00979d
 $beige = #f0e4db
-$blueberry = #564391
+$dusty-green = #72a475
+$pale-grey = #e1e0e4
+$aqua-marine = #50e3c2
 
+$black = #333
+$white = #eee
 $grey = #979797
-$light = #ccc;
+$light = #ccc
 
-$sans-font = "Open Sans", sans-serif
+$sans-font = "Roboto", sans-serif
 $mono-font = "LeagueMono", monospace
 
 $unit-size = 20px


### PR DESCRIPTION
## PR Overview
* This PR adds the shared Zooniverse header to the project.
![screen shot 2017-06-02 at 15 39 06](https://cloud.githubusercontent.com/assets/13952701/26730688/a82216e0-47a9-11e7-9328-f5449b3cd801.png)
* **Caveat:** this isn't the "real" Zooniverse header, just a placeholder.
  * We're expecting a new Zooniverse shared header from the Zooniverse-React-Components, but we don't have an ETC at the moment.
  * One option is to create a functional shared Zooniverse header specific for this project, then simply replace it when the 'real' header from the ZRC is confirmed.
* In any case, this PR also updates `app-themes.styl` to closer reflect the updated designs on Zeplin from the past 24 hours.