### PR TITLE
Retrieve Subject and Queue

### DIFF
--- a/src/containers/ClassifierTester.jsx
+++ b/src/containers/ClassifierTester.jsx
@@ -11,11 +11,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { fetchProject, PROJECT_STATUS } from '../ducks/project';
+import { fetchSubject, SUBJECT_STATUS } from '../ducks/subject';
 
 class ClassifierTester extends React.Component {
   constructor(props) {
     super(props);
     this.fetchProject = this.fetchProject.bind(this);
+    this.fetchSubject = this.fetchSubject.bind(this);
   }
 
   render() {
@@ -23,15 +25,20 @@ class ClassifierTester extends React.Component {
       <main className="app-content tester-page">
         <div className="control-panel">
           <button className="green button" onClick={this.fetchProject}>Fetch Project</button>
+          <button className="green button" onClick={this.fetchSubject}>Fetch Subject</button>
         </div>
         <div className="status-panel">
           {this.printProjectStatus()}
         </div>
+        <div className="status-panel">
+          {this.printSubjectStatus()}
+        </div>
         {this.printProjectData()}
+        {this.printSubjectData()}
       </main>
     );
   }
-  
+
   printProjectStatus() {
     switch (this.props.projectStatus) {
       case PROJECT_STATUS.IDLE:
@@ -46,13 +53,28 @@ class ClassifierTester extends React.Component {
         return 'I have no idea what\'s going on.';
     }
   }
-  
+
+  printSubjectStatus() {
+    switch (this.props.subjectStatus) {
+      case SUBJECT_STATUS.IDLE:
+        return 'Nothing yet';
+      case SUBJECT_STATUS.FETCHING:
+        return 'Hang on a second';
+      case SUBJECT_STATUS.READY:
+        return 'I found a subject!';
+      case SUBJECT_STATUS.ERROR:
+        return 'There was a problem';
+      default:
+        return 'What?';
+    }
+  }
+
   printProjectData() {
     if (!this.props.projectData || this.props.projectStatus !== PROJECT_STATUS.READY)
       return null;
-    
+
     const project = this.props.projectData;
-    
+
     return (
       <table className="data-panel">
         <tr>
@@ -74,16 +96,52 @@ class ClassifierTester extends React.Component {
       </table>
     );
   }
-  
+
+  printSubjectData() {
+    if (!this.props.currentSubject) {
+      return null;
+    }
+
+    return (
+      <table className="data-panel">
+        <tr>
+          <td>Current Subject ID:</td>
+          <td>{this.props.currentSubject.id}</td>
+        </tr>
+        <tr>
+          <td>Already Seen?:</td>
+          <td>{this.props.currentSubject.already_seen.toString()}</td>
+        </tr>
+        <tr>
+          <td>Subject Image:</td>
+          <td>
+            <img role="presentation" src={this.props.currentSubject.locations[0]['image/jpeg']} />
+          </td>
+        </tr>
+        <tr>
+          <td>Remaining queue length:</td>
+          <td>{this.props.queue.length} subjects</td>
+        </tr>
+      </table>
+    );
+  }
+
   fetchProject() {
     this.props.dispatch(fetchProject());
+  }
+
+  fetchSubject() {
+    this.props.dispatch(fetchSubject());
   }
 }
 
 ClassifierTester.propTypes = {
+  currentSubject: PropTypes.object,
   dispatch: PropTypes.func,
   projectStatus: PropTypes.string,
   projectData: PropTypes.object,
+  queue: PropTypes.array,
+  subjectStatus: PropTypes.string,
 };
 
 ClassifierTester.defaultProps = {
@@ -93,9 +151,12 @@ ClassifierTester.defaultProps = {
 
 const mapStateToProps = (state) => {
   return {
+    currentSubject: state.subject.currentSubject,
     projectStatus: state.project.status,
     projectData: state.project.data,
-  }
+    queue: state.subject.queue,
+    subjectStatus: state.subject.status,
+  };
 };
 
 export default connect(mapStateToProps)(ClassifierTester);

--- a/src/containers/ClassifierTester.jsx
+++ b/src/containers/ClassifierTester.jsx
@@ -10,6 +10,7 @@ service, without having to worry about the presentational side of things.
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import getSubjectLocation from '../lib/get-subject-location';
 import { fetchProject, PROJECT_STATUS } from '../ducks/project';
 import { fetchSubject, SUBJECT_STATUS } from '../ducks/subject';
 
@@ -102,6 +103,8 @@ class ClassifierTester extends React.Component {
       return null;
     }
 
+    const subjectLocation = getSubjectLocation(this.props.currentSubject);
+
     return (
       <table className="data-panel">
         <tr>
@@ -115,7 +118,7 @@ class ClassifierTester extends React.Component {
         <tr>
           <td>Subject Image:</td>
           <td>
-            <img role="presentation" src={this.props.currentSubject.locations[0]['image/jpeg']} />
+            <img role="presentation" src={subjectLocation.src} />
           </td>
         </tr>
         <tr>

--- a/src/ducks/reducer.js
+++ b/src/ducks/reducer.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import login from './login';
 import project from './project';
+import subject from './subject';
 
 export default combineReducers({
   login,
   project,
+  subject,
 });

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -1,0 +1,102 @@
+/*
+Redux Duck: Subject
+-------------------
+
+This duck (collection of redux actions + reducers) connects our app to the
+Zooniverse Panoptes API service, allowing us to retrieve subjects from a given
+project.
+
+ */
+import apiClient from 'panoptes-client/lib/api-client.js';
+
+const FETCH_SUBJECT = 'FETCH_SUBJECT';
+const FETCH_SUBJECT_SUCCESS = 'FETCH_SUBJECT_SUCCESS';
+const FETCH_SUBJECT_ERROR = 'FETCH_SUBJECT_ERROR';
+
+const TEMPORARY_HARDCODED_WORKFLOW_ID = '2628';
+const SUBJECT_STATUS = {
+  IDLE: 'subject_status_idle',
+  FETCHING: 'subject_status_fetching',
+  READY: 'subject_status_ready',
+  ERROR: 'subject_status_error',
+};
+
+const initialState = {
+  currentSubject: null,
+  id: null,
+  status: SUBJECT_STATUS.IDLE,
+  queue: [],
+};
+
+const subjectReducer = (state = initialState, action) => {
+  switch (action.type) {
+
+    case FETCH_SUBJECT:
+      return Object.assign({}, state, {
+        status: SUBJECT_STATUS.FETCHING,
+        id: action.id,
+      });
+
+    case FETCH_SUBJECT_SUCCESS:
+      return Object.assign({}, state, {
+        currentSubject: action.currentSubject,
+        status: SUBJECT_STATUS.READY,
+        queue: action.queue,
+      });
+
+    case FETCH_SUBJECT_ERROR:
+      return Object.assign({}, state, {
+        status: SUBJECT_STATUS.ERROR,
+      });
+
+    default:
+      return state;
+  }
+};
+
+const fetchSubject = (id = TEMPORARY_HARDCODED_WORKFLOW_ID) => {
+  return (dispatch, getState) => {
+
+    dispatch({
+      type: FETCH_SUBJECT,
+      id,
+    });
+
+    const subjectQuery = {
+      workflow_id: id,
+    };
+
+    const fetchQueue = () => {
+      apiClient.type('subjects/queued').get(subjectQuery)
+        .then((queue) => {
+          const currentSubject = queue.shift();
+          dispatch({
+            currentSubject,
+            queue,
+            type: FETCH_SUBJECT_SUCCESS,
+          });
+        })
+        .catch(() => {
+          dispatch({ type: FETCH_SUBJECT_ERROR });
+        });
+    };
+
+    if (!getState().subject.queue.length) {
+      fetchQueue();
+    } else {
+      const currentSubject = getState().subject.queue.shift();
+      dispatch({
+        currentSubject,
+        queue: getState().subject.queue,
+        type: FETCH_SUBJECT_SUCCESS,
+      });
+    }
+  };
+};
+
+export default subjectReducer;
+
+export {
+  fetchSubject,
+  SUBJECT_STATUS,
+};

--- a/src/lib/get-subject-location.js
+++ b/src/lib/get-subject-location.js
@@ -1,0 +1,24 @@
+const READABLE_FORMATS = {
+  image: ['jpeg', 'png', 'svg+xml', 'gif'],
+};
+
+function getSubjectLocation(subject, frame = 0) {
+  let format;
+  let type;
+  let src;
+
+  const currentLocation = subject.locations[frame];
+
+  Object.keys(currentLocation).some((mimeType) => {
+    src = currentLocation[mimeType];
+    [type, format] = mimeType.split('/');
+    const extensions = type || [];
+    if (type in READABLE_FORMATS && READABLE_FORMATS[extensions].includes(format)) {
+      return type;
+    }
+  });
+
+  return { type, format, src };
+}
+
+export default getSubjectLocation;

--- a/src/styles/components/tester-page.styl
+++ b/src/styles/components/tester-page.styl
@@ -2,23 +2,26 @@
   font-size: 0.75rem
   background: $dark-grey
   color: $dark-grey
-  
+
   > div
     background: $light-grey
     margin: 1em
     padding: 1em
-    
+
   .control-panel
     border: 1px solid $teal
-  
+
+    button
+      margin: 0 0.5em
+
   .status-panel
     border: 1px solid $aqua-marine
-  
+
   .data-panel
     background: $light-grey
     margin: 1em
     padding: 0
-    
+
     td
       padding: 0.5em
       vertical-align: top


### PR DESCRIPTION
This is based pretty closely to the project retrieval with the addition of the queue. There might be some intrinsic changes that need to be made, as this is the second time I've used Redux, so I'm open to suggestions.

Working through this, there should also be a subject location reader helper method, similar to what exists in PFE. I might push this up in another commit, but if you review this before that commit, feel free to merge and I'll add the addition in another PR. 