### PR TITLE
'Reset Image' functionality also does auto-best-fit of Image size

### DIFF
--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import {
-  setRotation, setScaling, resetTransformations,
+  setRotation, setScaling, resetView,
   setViewerState, SUBJECTVIEWER_STATE,
 } from '../ducks/subject-viewer';
 
@@ -153,7 +153,7 @@ class ClassifierContainer extends React.Component {
   }
 
   useResetImage() {
-    this.props.dispatch(resetTransformations());
+    this.props.dispatch(resetView());
   }
 }
 

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -24,8 +24,9 @@ import SVGImage from '../components/SVGImage';
 import { Utility } from '../lib/Utility';
 
 import {
-  setRotation, setScaling, setTranslation,
-  setViewerState, SUBJECTVIEWER_STATE,
+  setRotation, setScaling, setTranslation, resetView,
+  setViewerState, updateViewerSize, updateImageSize,
+  SUBJECTVIEWER_STATE,
 } from '../ducks/subject-viewer';
 
 const INPUT_STATE = {
@@ -47,7 +48,7 @@ class SubjectViewer extends React.Component {
     
     //Events!
     this.updateSize = this.updateSize.bind(this);
-    this.fitSubjectToContainer = this.fitSubjectToContainer.bind(this);
+    this.onImageLoad = this.onImageLoad.bind(this);
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
@@ -89,7 +90,7 @@ class SubjectViewer extends React.Component {
             <SVGImage
               ref={(c)=>{this.svgImage=c}}
               src="https://panoptes-uploads.zooniverse.org/production/subject_location/97af440c-15d2-4fb1-bc18-167c9151050a.jpeg"
-              onLoad={this.fitSubjectToContainer}
+              onLoad={this.onImageLoad}
             />
           </g>
           {(!DEV_MODE) ? null :
@@ -153,20 +154,23 @@ class SubjectViewer extends React.Component {
     this.svg.setAttribute('viewBox', `${-w/2} ${(-h/2)} ${w} ${h}`);
     this.svg.style.width = w + 'px';
     this.svg.style.height = h + 'px';
+    
+    //Record the changes.
+    const boundingBox = this.getBoundingBox();
+    const svgW = boundingBox.width;
+    const svgH = boundingBox.height;
+    this.props.dispatch(updateViewerSize(svgW, svgH));
   }
   
   /*  Once the Subject has been loaded properly, fit it into the SVG Viewer.
    */
-  fitSubjectToContainer() {
+  onImageLoad() {
     if (this.svgImage.image) {
       const imgW = (this.svgImage.image.width) ? this.svgImage.image.width : 1;
       const imgH = (this.svgImage.image.height) ? this.svgImage.image.height : 1;
-      const boundingBox = this.getBoundingBox();
-      const svgW = boundingBox.width;
-      const svgH = boundingBox.height;
-      const scaleW = svgW / imgW;
-      const scaleH = svgH / imgH;
-      this.props.dispatch(setScaling(Math.min(scaleW, scaleH)));
+      
+      this.props.dispatch(updateImageSize(imgW, imgH));
+      this.props.dispatch(resetView());  
     }
   }
   

--- a/src/ducks/subject-viewer.js
+++ b/src/ducks/subject-viewer.js
@@ -18,19 +18,26 @@ const MAX_SCALING = 10;
 
 //Initial State
 const initialState = {
+  //Image transformations
   rotation: 0,
   scaling: 1,
   translationX: 0,
   translationY: 0,
+  
+  //Viewer settings
   viewerState: SUBJECTVIEWER_STATE.NAVIGATING,
+  viewerSize: { width: 0, height: 0 },
+  imageSize: { width: 0, height: 0 },
 };
 
 //Action Types
 const SET_ROTATION = 'SET_ROTATION';
 const SET_SCALING = 'SET_SCALING';
 const SET_TRANSLATION = 'SET_TRANSLATION';
-const RESET_TRANSFORMATIONS = 'RESET_TRANSFORMATIONS';
+const RESET_VIEW = 'RESET_VIEW';
 const SET_VIEWER_STATE = 'SET_VIEWER_STATE';
+const UPDATE_VIEWER_SIZE = 'UPDATE_VIEWER_SIZE';
+const UPDATE_IMAGE_SIZE = 'UPDATE_IMAGE_SIZE';
 
 /*
 --------------------------------------------------------------------------------
@@ -63,10 +70,19 @@ const subjectViewerReducer = (state = initialState, action) => {
         translationY: action.y,
       });
       
-    case RESET_TRANSFORMATIONS:
+    case RESET_VIEW:
+      let bestFitScale = 1;
+      if (state.viewerSize.width && state.viewerSize.height &&
+          state.imageSize.width && state.imageSize.height) {
+        bestFitScale = Math.min(
+          state.viewerSize.width / state.imageSize.width,
+          state.viewerSize.height / state.imageSize.height
+        );
+      }
+      
       return Object.assign({}, state, {
         rotation: 0,
-        scaling: 1,
+        scaling: bestFitScale,
         translationX: 0,
         translationY: 0,
       });
@@ -74,6 +90,22 @@ const subjectViewerReducer = (state = initialState, action) => {
     case SET_VIEWER_STATE:
       return Object.assign({}, state, {
         viewerState: action.viewerState,
+      });
+      
+    case UPDATE_VIEWER_SIZE:
+      return Object.assign({}, state, {
+        viewerSize: {
+          width: action.width,
+          height: action.height,
+        },
+      });
+    
+    case UPDATE_IMAGE_SIZE:
+      return Object.assign({}, state, {
+        imageSize: {
+          width: action.width,
+          height: action.height,
+        },
       });
     
     default:
@@ -112,10 +144,10 @@ const setTranslation = (x, y) => {
   }
 };
 
-const resetTransformations = () => {
+const resetView = () => {
   return (dispatch) => {
     dispatch({
-      type: RESET_TRANSFORMATIONS,
+      type: RESET_VIEW,
     });
   }
 };
@@ -125,6 +157,24 @@ const setViewerState = (viewerState) => {
     dispatch({
       type: SET_VIEWER_STATE,
       viewerState,
+    });
+  }
+};
+
+const updateViewerSize = (width, height) => {
+  return (dispatch) => {
+    dispatch({
+      type: UPDATE_VIEWER_SIZE,
+      width, height,
+    });
+  }
+};
+
+const updateImageSize = (width, height) => {
+  return (dispatch) => {
+    dispatch({
+      type: UPDATE_IMAGE_SIZE,
+      width, height,
     });
   }
 };
@@ -139,7 +189,9 @@ export {
   setRotation,
   setScaling,
   setTranslation,
-  resetTransformations,
+  resetView,
   setViewerState,
+  updateViewerSize,
+  updateImageSize,
   SUBJECTVIEWER_STATE,
 };


### PR DESCRIPTION
## PR Overview
* This PR fixes #23 
* With this PR, calling the 'Reset Image' functionality (either on Subject image load, or when clicking the 'Reset Image' button on the Classifier controls) also calls the 'best fit Subject image to viewer' functionality.
* As a result of these changes, the Image Size and Subject Viewer Size data is now stored within the Redux store.

### Status
Ready for review