### PR TITLE
Add "Deploy to Production" command line action

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha $(find src -name *.spec.jsx) --compilers js:babel-core/register || true",
     "test-travis": "NODE_ENV=development BABEL_ENV=test mocha $(find src -name *.spec.jsx) --compilers js:babel-core/register || true",
     "eslint": "eslint .",
-    "build": "BABEL_ENV=production webpack --config webpack.production.config.js -p"
+    "build": "BABEL_ENV=production webpack --config webpack.production.config.js -p",
+    "deploy-production": "NODE_ENV=production npm run build && publisssh dist zooniverse-static/www.antislaverymanuscripts.org"
   },
   "author": "Zooniverse",
   "license": "Apache-2.0",
@@ -64,6 +65,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^3.2.0",
     "nib": "^1.1.2",
+    "publisssh": "^1.1.0",
     "react-addons-test-utils": "^15.4.2",
     "react-test-renderer": "^15.4.2",
     "rimraf": "^2.5.4",

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -77,11 +77,7 @@ module.exports = {
       }),
     }, {
       test: /\.(jpg|png|gif|otf|eot|svg|ttf|woff\d?)$/,
-      use: [{
-        loader: 'file-loader',
-      }, {
-        loader: 'image-webpack-loader',
-      }],
+      loader: 'file-loader',
     }],
   },
 


### PR DESCRIPTION
## PR Overview
* In this PR, we're adding the ability for us to publish our website to https://www.antislaverymanuscripts.org/
* To do so, run `npm run deploy-production` on the command line.
  * Of course, this only applies to Zooniverse developers with access to the production servers.
* Note that due production-staging shenanigans, if you view https://www.antislaverymanuscripts.org/ new, you'll see some Subjects from Notes from Nature (butterflies!) instead of something more text/transcription-based. This is because that, for testing, the project/subject queue/etc IDs are all hard-coded and the NfN project is what you see on production; to view the 'proper' testing images, add the `staging` switch: https://www.antislaverymanuscripts.org/?env=staging

### Status
Ready for review! Don't forget to run `npm install` before you start