### PR TITLE
Bugfix: Hide 'Test Popup' when loading Classifier Page

### DIFF
--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -31,14 +31,8 @@ class ClassifierContainer extends React.Component {
   
     //TEMPORARY
     this.state = {
-      TEST_POPUP: (
-        <div>
-          <div>If there's something strange</div>
-          <div>In your neighbourhood</div>
-          <div>Who you gonna call?</div>
-        </div>
-      )
-    };
+      TEST_POPUP: null,
+    }
   }
 
   //----------------------------------------------------------------
@@ -160,6 +154,13 @@ class ClassifierContainer extends React.Component {
               </span>
               <span>Subject Info</span>
             </button>
+            
+            <button className="flat-button block" onClick={this.TEST_OPEN_POPUP.bind(this)}>
+              <span className="classifier-toolbar__icon">
+                <i className="fa fa-exclamation-triangle" />
+              </span>
+              <span>Test Popup</span>
+            </button>
           </div>
         </section>
         
@@ -173,6 +174,17 @@ class ClassifierContainer extends React.Component {
   }
 
   //----------------------------------------------------------------
+
+  TEST_OPEN_POPUP() {
+    this.setState({ TEST_POPUP: (
+      <div>
+        <h1>Hello World!</h1>
+        <h2>Sample popup</h2>
+        <p>This is an example of how we can add popup messages (and similar things) to our project.</p>
+        <p>This will be useful for error messages and info boxes.</p>
+      </div>
+    ) });
+  }
 
   TEST_CLOSE_POPUP() {
     this.setState({ TEST_POPUP: null });


### PR DESCRIPTION
## PR Overview
* Minor bugfix
* Currently, when we open the Classifier Page, the test popup... pops up.
* This makes development a bit of annoyance, what with our frequent page reloads.
* As such, I've hidden the Test Popup so it only appears when you click on the "Test Popup" button on the Classifier page. (See the right-hand tools)
* Obviously, once we start using the popup mechanics for proper messaging, we can remove the example used in the Classifier page.

### Status
I'm merging this straight away so dev work won't be hindered by the unexpected popups. Tagging @wgranger as a FYI.