### PR TITLE
Fix Image size/Resizing

### DIFF
--- a/src/containers/Navigator.jsx
+++ b/src/containers/Navigator.jsx
@@ -79,10 +79,10 @@ Navigator.propTypes = {
   currentSubject: PropTypes.shape({
     src: PropTypes.string,
   }),
-  imageSize: {
+  imageSize: PropTypes.shape({
     width: PropTypes.number,
     height: PropTypes.number,
-  },
+  }),
   dispatch: PropTypes.func,
   rotation: PropTypes.number,
   scaling: PropTypes.number,


### PR DESCRIPTION
## PR Overview
* The PR was originally an attempt to fix why the Subject images aren't fitting properly into Subject Viewer.
![screen shot 2017-08-07 at 13 13 48](https://user-images.githubusercontent.com/13952701/29026177-5d7e6e7a-7b72-11e7-94d2-fcbe0ead0631.png)
_Look at that Subject image, it's so tiny. It should fit neatly into the Subject Viewer's viewport._
* But then I realised... the Subject Images themselves were wonky, with plenty of empty space to the left and right. (e.g. https://panoptes-uploads.zooniverse.org/staging/subject_location/f9e4c84c-169c-44a2-b0bd-153602bd366f.png )
![screen shot 2017-08-07 at 13 14 12](https://user-images.githubusercontent.com/13952701/29026199-7ac723be-7b72-11e7-9042-133687291a1d.png)
_What in the..._
* Instead, the only substantial change in this PR is the fix of Navigator's `Navigator.props.imageSize` PropTypes, which wasn't using the PropType.shape that it should have.

### Status
Ready for review. The question of wide Subject Images is probably something separate to explore...