### PR TITLE
Add Footer from Shared Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "redux-devtools-extension": "^1.0.0",
     "redux-logger": "^2.7.4",
     "redux-thunk": "^2.1.0",
-    "zooniverse-react-components": "git+ssh://git@github.com/zooniverse/Zooniverse-React-Components.git#v0.2.0"
+    "zoo-grommet": "^0.2.1",
+    "zooniverse-react-components": "github:zooniverse/Zooniverse-react-components#v0.4.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.5.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "redux-logger": "^2.7.4",
     "redux-thunk": "^2.1.0",
     "zoo-grommet": "^0.2.1",
-    "zooniverse-react-components": "github:zooniverse/Zooniverse-react-components#v0.4.2"
+    "zooniverse-react-components": "github:zooniverse/Zooniverse-react-components#v0.4.3"
   },
   "devDependencies": {
     "autoprefixer": "^6.5.3",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -23,8 +23,10 @@ class App extends React.Component {
       <div>
         <Header />
         <ProjectHeader showTitle={showTitle} />
-          {this.props.children}
-        <ZooFooter />
+        {this.props.children}
+        <div className="grommet">
+          <ZooFooter />
+        </div>
       </div>
     );
   }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { ZooFooter } from 'zooniverse-react-components';
 import { fetchProject } from '../ducks/project';
 import Header from './Header';
 import ProjectHeader from './ProjectHeader';
@@ -22,7 +23,8 @@ class App extends React.Component {
       <div>
         <Header />
         <ProjectHeader showTitle={showTitle} />
-        {this.props.children}
+          {this.props.children}
+        <ZooFooter />
       </div>
     );
   }

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -78,7 +78,7 @@ class Home extends React.Component {
         <div className="home-page__community">
         </div>
         <div className="home-page__zooniverse">
-          <ZooniverseLogo height="3.5em" width="3.5em" />
+          <ZooniverseLogo className="zooniverse-logo" height="3.5em" width="3.5em" />
           <span>
             The Zooniverse is the world&#39;s largest and most popular platform
             for people-powered research. This research is made possible by

--- a/src/styles/components/app-header.styl
+++ b/src/styles/components/app-header.styl
@@ -16,6 +16,7 @@
 
   &__nav-links
     list-style: none
+    margin: 1em 0.75em
     padding-left: 0
 
   &__link

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -163,22 +163,25 @@
     color: $white
     display: flex
     flex-direction: column
-    padding: 0 22%
+    padding: 2em 22%
     text-align: center
 
-    .zooniverse-logo
+    svg
       color: $light-teal
-      margin: 2.25em auto
+      margin: 0 auto 2.25em auto
 
     span
       @extend .secondary-head
       color: $light-grey
       letter-spacing: 0.12em
+      font-size: 0.8em
+      line-height: 1.7em
 
     a
       @extend .text-links
       color: $white
-      margin: 2em 0 3em 0
+      font-weight: 400
+      margin-top: 2em
 
   .project-background
     background-image: url('../images/home-bg.jpg')

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -166,7 +166,7 @@
     padding: 2em 22%
     text-align: center
 
-    svg
+    .zooniverse-logo
       color: $light-teal
       margin: 0 auto 2.25em auto
 

--- a/src/styles/components/temp-placeholders.styl
+++ b/src/styles/components/temp-placeholders.styl
@@ -66,10 +66,6 @@
   display: flex
   flex-direction: row
 
-.grommet
-  img
-    width: 62px
-
 .grommetux-menu
   font-size: 1em
 

--- a/src/styles/components/temp-placeholders.styl
+++ b/src/styles/components/temp-placeholders.styl
@@ -65,3 +65,19 @@
 .flex-column
   display: flex
   flex-direction: row
+
+.grommet
+  font-size: 14px
+
+footer
+  border-top: 5px solid #005d69
+
+.grommetux-menu
+  font-size: 1em
+
+#root section:not(.grommetux-section)
+  padding-top: 0
+  padding-bottom: 0
+
+:not(.grommet) button
+  line-height: 1em

--- a/src/styles/components/temp-placeholders.styl
+++ b/src/styles/components/temp-placeholders.styl
@@ -67,10 +67,8 @@
   flex-direction: row
 
 .grommet
-  font-size: 14px
-
-footer
-  border-top: 5px solid #005d69
+  img
+    width: 62px
 
 .grommetux-menu
   font-size: 1em

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -1,7 +1,7 @@
 @import "nib"
 
-@import "~zooniverse-react-components/lib/zooniverse-react-components.css"
 @import "~zoo-grommet/dist/zoo-grommet.css"
+@import "~zooniverse-react-components/lib/zooniverse-react-components.css"
 
 @import "global/*"
 @import "components/*"

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -1,7 +1,7 @@
 @import "nib"
 
+@import "~zooniverse-react-components/lib/zooniverse-react-components.css"
+@import "~zoo-grommet/dist/zoo-grommet.css"
+
 @import "global/*"
 @import "components/*"
-
-@import "../../node_modules/zooniverse-react-components/lib/zooniverse-react-components.css"
-@import "~zoo-grommet/dist/zoo-grommet.css"

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -2,3 +2,6 @@
 
 @import "global/*"
 @import "components/*"
+
+@import "../../node_modules/zooniverse-react-components/lib/zooniverse-react-components.css"
+@import "~zoo-grommet/dist/zoo-grommet.css"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,9 @@ module.exports = {
         loader: 'style-loader',
       }, {
         loader: 'css-loader',
+        options: {
+           includePaths: [path.resolve(__dirname, 'node_modules/zoo-grommet/dist')]
+        }
       }, {
         loader: 'stylus-loader',
         options: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ module.exports = {
       }, {
         loader: 'css-loader',
         options: {
-           includePaths: [path.resolve(__dirname, 'node_modules/zoo-grommet/dist')]
+           includePaths: [path.resolve(__dirname, 'node_modules/zoo-grommet/dist'), path.resolve(__dirname, 'node_modules/zooniverse-react-components/lib/zooniverse-react-components.css')]
         }
       }, {
         loader: 'stylus-loader',

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -68,6 +68,9 @@ module.exports = {
         fallback: 'style-loader',
         use: [{
           loader: 'css-loader',
+          options: {
+             includePaths: [path.resolve(__dirname, 'node_modules/zoo-grommet/dist')]
+          }
         }, {
           loader: 'stylus-loader',
           options: {

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -69,7 +69,7 @@ module.exports = {
         use: [{
           loader: 'css-loader',
           options: {
-             includePaths: [path.resolve(__dirname, 'node_modules/zoo-grommet/dist')]
+             includePaths: [path.resolve(__dirname, 'node_modules/zoo-grommet/dist'), path.resolve(__dirname, 'node_modules/zooniverse-react-components/lib/zooniverse-react-components.css')]
           }
         }, {
           loader: 'stylus-loader',


### PR DESCRIPTION
In this PR, the footer is added from the newly updated Zooniverse-react-components repo. As the repo uses Grommet, several styling changes affected the view of the app, which is reflected in the CSS changes also made in this PR. 