### PR TITLE
Move Zoom Tools to Subject Viewer

### DIFF
--- a/src/components/ZoomTools.jsx
+++ b/src/components/ZoomTools.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SUBJECTVIEWER_STATE } from '../ducks/subject-viewer';
+
+const ZoomTools = ({ viewerState, usePanTool, useZoomIn, useZoomOut }) => {
+  return (
+    <div className="zoom-tools">
+      <button className="flat-button block" onClick={useZoomIn}>
+        <i className="fa fa-plus" />
+      </button>
+
+      <button className="flat-button block" onClick={useZoomOut}>
+        <i className="fa fa-minus" />
+      </button>
+
+      <button
+        className={(viewerState === SUBJECTVIEWER_STATE.NAVIGATING) ? 'flat-button block selected' : 'flat-button block'}
+        onClick={usePanTool}
+      >
+        <i className="fa fa-arrows" />
+      </button>
+    </div>
+
+  );
+};
+
+ZoomTools.propTypes = {
+  usePanTool: PropTypes.func,
+  useZoomIn: PropTypes.func,
+  useZoomOut: PropTypes.func,
+  viewerState: PropTypes.string
+};
+
+export default ZoomTools;

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import {
-  setRotation, setScaling, setContrast,
-  resetView, setViewerState, SUBJECTVIEWER_STATE,
+  setRotation, setContrast, resetView,
+  setViewerState, SUBJECTVIEWER_STATE,
 } from '../ducks/subject-viewer';
 
 import { toggleFavorite } from '../ducks/subject';
@@ -18,10 +18,10 @@ import FavoritesButton from '../components/FavoritesButton';
 import Popup from '../components/Popup';
 import SelectedAnnotation from '../components/SelectedAnnotation';
 import ShowMetadata from '../components/ShowMetadata';
+import ZoomTools from '../components/ZoomTools';
 import CollectionsContainer from './CollectionsContainer';
 import Divider from '../images/img_divider.png';
 
-const ZOOM_STEP = 0.1;
 const ROTATION_STEP = 90;
 
 class ClassifierContainer extends React.Component {
@@ -30,9 +30,6 @@ class ClassifierContainer extends React.Component {
 
     //Bind events
     this.useAnnotationTool = this.useAnnotationTool.bind(this);
-    this.usePanTool = this.usePanTool.bind(this);
-    this.useZoomIn = this.useZoomIn.bind(this);
-    this.useZoomOut = this.useZoomOut.bind(this);
     this.useRotate90 = this.useRotate90.bind(this);
     this.useResetImage = this.useResetImage.bind(this);
     this.useContrast = this.useContrast.bind(this);
@@ -94,30 +91,6 @@ class ClassifierContainer extends React.Component {
                 <i className="fa fa-plus-circle" />
               </span>
               <span>Annotate</span>
-            </button>
-
-            <button
-              className={(this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING) ? 'flat-button block selected' : 'flat-button block'}
-              onClick={this.usePanTool}
-            >
-              <span className="classifier-toolbar__icon">
-                <i className="fa fa-arrows" />
-              </span>
-              <span>Pan image</span>
-            </button>
-
-            <button className="flat-button block" onClick={this.useZoomIn}>
-              <span className="classifier-toolbar__icon">
-                <i className="fa fa-plus" />
-              </span>
-              <span>Zoom In</span>
-            </button>
-
-            <button className="flat-button block" onClick={this.useZoomOut}>
-              <span className="classifier-toolbar__icon">
-                <i className="fa fa-minus" />
-              </span>
-              <span>Zoom Out</span>
             </button>
 
             <button className="flat-button block" onClick={this.useRotate90}>
@@ -202,18 +175,6 @@ class ClassifierContainer extends React.Component {
 
   useAnnotationTool() {
     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
-  }
-
-  usePanTool() {
-    this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.NAVIGATING));
-  }
-
-  useZoomIn() {
-    this.props.dispatch(setScaling(this.props.scaling + ZOOM_STEP));
-  }
-
-  useZoomOut() {
-    this.props.dispatch(setScaling(this.props.scaling - ZOOM_STEP));
   }
 
   useRotate90() {

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -24,6 +24,7 @@ import { connect } from 'react-redux';
 import FilmstripViewer from '../components/FilmstripViewer';
 import SVGImage from '../components/SVGImage';
 import AnnotationsPane from '../components/AnnotationsPane';
+import ZoomTools from '../components/ZoomTools';
 import { Utility } from '../lib/Utility';
 import { fetchSubject, SUBJECT_STATUS } from '../ducks/subject';
 import { getSubjectLocation } from '../lib/get-subject-location';
@@ -43,6 +44,8 @@ const INPUT_STATE = {
   IDLE: 0,
   ACTIVE: 1,
 }
+
+const ZOOM_STEP = 0.1;
 
 //Add ?dev=1 to the URL to enable DEV_MODE
 const DEV_MODE = window.location && /(\?|&)dev(=|&|$)/ig.test(window.location.search);
@@ -71,6 +74,9 @@ class SubjectViewer extends React.Component {
     this.getPointerXYOnImage = this.getPointerXYOnImage.bind(this);
     this.onCompleteAnnotation = this.onCompleteAnnotation.bind(this);
     this.onSelectAnnotation = this.onSelectAnnotation.bind(this);
+    this.usePanTool = this.usePanTool.bind(this);
+    this.useZoomIn = this.useZoomIn.bind(this);
+    this.useZoomOut = this.useZoomOut.bind(this);
 
     //Mouse or touch pointer
     this.pointer = {
@@ -93,13 +99,14 @@ class SubjectViewer extends React.Component {
   render() {
     const transform = `scale(${this.props.scaling}) translate(${this.props.translationX}, ${this.props.translationY}) rotate(${this.props.rotation}) `;
     let subjectLocation = undefined;
+    const cursor = this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING ? 'cursor-move' : '';
 
     if (this.props.currentSubject) subjectLocation = getSubjectLocation(this.props.currentSubject, this.props.frame).src;
 
     return (
-      <section className="subject-viewer" ref={(c)=>{this.section=c}}>
+      <section className={`subject-viewer ${cursor}`} ref={(c)=>{this.section=c}}>
 
-        {/* <FilmstripViewer /> */}
+        <ZoomTools viewerState={this.props.viewerState} usePanTool={this.usePanTool} useZoomIn={this.useZoomIn} useZoomOut={this.useZoomOut} />
 
         <svg
           ref={(c)=>{this.svg=c}}
@@ -221,6 +228,18 @@ class SubjectViewer extends React.Component {
       this.props.dispatch(updateImageSize(imgW, imgH));
       this.props.dispatch(resetView());
     }
+  }
+
+  usePanTool() {
+    this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.NAVIGATING));
+  }
+
+  useZoomIn() {
+    this.props.dispatch(setScaling(this.props.scaling + ZOOM_STEP));
+  }
+
+  useZoomOut() {
+    this.props.dispatch(setScaling(this.props.scaling - ZOOM_STEP));
   }
 
   //----------------------------------------------------------------

--- a/src/styles/components/subject-viewer.styl
+++ b/src/styles/components/subject-viewer.styl
@@ -11,6 +11,9 @@
 .filmstrip-viewer
   position: relative
 
+.cursor-move
+  cursor: move
+
 .related-images
   background: $mid-grey
   height: 100%

--- a/src/styles/components/zoom-tools.styl
+++ b/src/styles/components/zoom-tools.styl
@@ -1,0 +1,19 @@
+.zoom-tools
+  margin: 0 0.25em
+  position: absolute
+
+  > .block
+    background-color: white
+    box-shadow: 2px 2px 5px #888888
+    margin: 0.2rem 0
+    padding: 0.25em
+    width: 1.5em
+
+  .selected
+    color: $red-orange
+
+  button
+    justify-content: center
+
+    &:focus
+      outline: 0


### PR DESCRIPTION
Fixes #52 Fixes #22 

Per design suggestions, this PR moves zoom and pan functionality to the subject viewer. The cursor has also changed to a move icon when navigating.