### PR TITLE
Fix Subject Viewer Overflow

### DIFF
--- a/src/styles/components/subject-viewer.styl
+++ b/src/styles/components/subject-viewer.styl
@@ -1,6 +1,6 @@
 .subject-viewer
   flex: 1 1 auto
-  overflow: hidden
+  overflow: inherit
   background: #333  //TMP: visual differentiator for the Subject
   border: 1px solid #333  //TMP: Borders offer visual differentiation but may interfere with precise mathematical calculations of width.
 


### PR DESCRIPTION
This is a fix on the subject viewer overflow. Currently, the annotation pane is hidden behind any content besides the subject viewer container.