### PR TITLE
Fix 72: AnnotationsPane now checks for currentAnnotations.clusters_text

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -169,7 +169,7 @@ class AnnotationsPane extends React.Component {
       const annotationData = [];
       const currentAnnotations = reduction.data[`frame${this.props.frame}`];
 
-      if (currentAnnotations) {
+      if (currentAnnotations && currentAnnotations.clusters_text) {
         currentAnnotations.clusters_text.map((text, i) => {
           const data = {
             points: [{


### PR DESCRIPTION
## PR Overview
* Fixes #72 
* Classifications page on localhost:3000/classify would have issues rendering some Subjects (presumably, those without previous markings)
* Turns out this was due to `AnnotationsPane.renderPreviousAnnotations` not checking the existence of `currentAnnotations.clusters_text` before trying to `.map()` it.
* Fix is a simple check before execution.

### NOTE
* @wgranger it occurs to me that the reason I didn't catch this earlier was because the `currentAnnotations.clusters_text` was _always_ provided... which hints that Caesar is likely now _live_ with the new text aggregation updates, wooo ( https://github.com/zooniverse/aggregation-for-caesar/pull/34 )

### Status
Ready for review just in case there's anything else obvious I missed. Otherwise, since this is minor, I'll merge within 24 hours.