### PR TITLE
Feature: Delete Selected Annotation

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -3,7 +3,7 @@ import Rnd from 'react-rnd';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { collaborateWithAnnotation, updateText, deleteSelectedAnnotation } from '../ducks/annotations';
-import { updatePreviousAnnotation } from '../ducks/previousAnnotations';
+import { updatePreviousAnnotation, reenablePreviousAnnotation } from '../ducks/previousAnnotations';
 
 const PANE_WIDTH = 800;
 const PANE_HEIGHT = 260;
@@ -167,6 +167,7 @@ class SelectedAnnotation extends React.Component {
   }
   
   deleteAnnotation() {
+    this.props.dispatch(reenablePreviousAnnotation());
     this.props.dispatch(deleteSelectedAnnotation());
     this.props.onClose();  //Note that deleteSelectedAnnotation() also runs unselectAnnotation(), but this needs to be called anyway to inform the parent component.
   }

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -131,14 +131,11 @@ class SelectedAnnotation extends React.Component {
           </div>
 
           <div className="selected-annotation__buttons">
-            {(this.props.annotation.previousAnnotation) ? null :
-              <span>
-                <button onClick={this.deleteAnnotation}>DELETE DELETE DELETE</button>
-                {' | '}
-              </span>
-            }
             <button onClick={this.saveText}>Done</button>
             <button onClick={this.props.onClose}>Cancel</button>
+            {(this.props.annotation.previousAnnotation) ? null :
+              <button onClick={this.deleteAnnotation}>Delete</button>
+            }
           </div>
         </div>
       </Rnd>
@@ -171,7 +168,7 @@ class SelectedAnnotation extends React.Component {
   
   deleteAnnotation() {
     this.props.dispatch(deleteSelectedAnnotation());
-    this.props.onClose();
+    this.props.onClose();  //Note that deleteSelectedAnnotation() also runs unselectAnnotation(), but this needs to be called anyway to inform the parent component.
   }
 
   onTextUpdate() {

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Rnd from 'react-rnd';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { collaborateWithAnnotation, updateText } from '../ducks/annotations';
+import { collaborateWithAnnotation, updateText, deleteSelectedAnnotation } from '../ducks/annotations';
 import { updatePreviousAnnotation } from '../ducks/previousAnnotations';
 
 const PANE_WIDTH = 800;
@@ -19,6 +19,7 @@ class SelectedAnnotation extends React.Component {
     this.onTextUpdate = this.onTextUpdate.bind(this);
     this.toggleShowAnnotations = this.toggleShowAnnotations.bind(this);
     this.saveText = this.saveText.bind(this);
+    this.deleteAnnotation = this.deleteAnnotation.bind(this);
 
     this.state = {
       annotationText: '',
@@ -59,7 +60,7 @@ class SelectedAnnotation extends React.Component {
   }
 
   render() {
-    if (!this.props.annotation) return null;
+    if (!this.props.annotation || !this.props.annotationPanePosition) return null;
 
     const panePosition = this.props.annotationPanePosition;
     const rotation = -this.props.rotation / 180 * Math.PI;
@@ -130,6 +131,12 @@ class SelectedAnnotation extends React.Component {
           </div>
 
           <div className="selected-annotation__buttons">
+            {(this.props.annotation.previousAnnotation) ? null :
+              <span>
+                <button onClick={this.deleteAnnotation}>DELETE DELETE DELETE</button>
+                {' | '}
+              </span>
+            }
             <button onClick={this.saveText}>Done</button>
             <button onClick={this.props.onClose}>Cancel</button>
           </div>
@@ -159,6 +166,11 @@ class SelectedAnnotation extends React.Component {
     } else {
       this.props.dispatch(updateText(this.state.annotationText));
     }
+    this.props.onClose();
+  }
+  
+  deleteAnnotation() {
+    this.props.dispatch(deleteSelectedAnnotation());
     this.props.onClose();
   }
 

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -11,6 +11,7 @@ const ADD_ANNOTATION_POINT = 'ADD_ANNOTATION_POINT';
 const COMPLETE_ANNOTATION = 'COMPLETE_ANNOTATION';
 const SELECT_ANNOTATION = 'SELECT_ANNOTATION';
 const UNSELECT_ANNOTATION = 'UNSELECT_ANNOTATION';
+const DELETE_SELECTED_ANNOTATION = 'DELETE_SELECTED_ANNOTATION';
 const COLLABORATE_WITH_ANNOTATION = 'COLLABORATE_WITH_ANNOTATION';
 const UPDATE_TEXT = 'UPDATE_TEXT';
 const SAVE_TEXT = 'SAVE_TEXT';
@@ -108,6 +109,17 @@ const subjectReducer = (state = initialState, action) => {
         selectedAnnotation: null,
         selectedAnnotationIndex: null
       });
+    
+    case DELETE_SELECTED_ANNOTATION:
+      let filteredAnnotations = [];
+      if (state.annotations && state.selectedAnnotationIndex !== null) {
+        filteredAnnotations = state.annotations.filter((item, index) => {
+          return index !== state.selectedAnnotationIndex;
+        });
+      }
+      return Object.assign({}, state, {
+        annotations: filteredAnnotations,
+      });
 
     default:
       return state;
@@ -151,6 +163,14 @@ const unselectAnnotation = () => {
   };
 };
 
+const deleteSelectedAnnotation = () => {
+  return (dispatch) => {
+    dispatch({
+      type: DELETE_SELECTED_ANNOTATION,
+    });
+  };
+};
+
 const completeAnnotation = () => {
   return (dispatch) => {
     dispatch({
@@ -186,6 +206,7 @@ export default subjectReducer;
 export {
   addAnnotationPoint, completeAnnotation,
   selectAnnotation, unselectAnnotation,
+  deleteSelectedAnnotation,
   collaborateWithAnnotation,
   updateText, ANNOTATION_STATUS
 };

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -119,6 +119,10 @@ const subjectReducer = (state = initialState, action) => {
       }
       return Object.assign({}, state, {
         annotations: filteredAnnotations,
+        //Note: delete_selected_annotation also performs unselect_annotation.
+        annotationPanePosition: null,
+        selectedAnnotation: null,
+        selectedAnnotationIndex: null,
       });
 
     default:

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -14,6 +14,7 @@ const CAESAR_HOST = 'https://caesar-staging.zooniverse.org/graphql';
 const FETCH_ANNOTATIONS = 'FETCH_ANNOTATIONS';
 const UPDATE_FRAME ='UPDATE_FRAME';
 const UPDATE_PREVIOUS_ANNOTATION = 'UPDATE_PREVIOUS_ANNOTATION';
+const REENABLE_PREVIOUS_ANNOTATION = 'REENABLE_PREVIOUS_ANNOTATION';
 
 const previousAnnotationsReducer = (state = initialState, action) => {
   switch (action.type) {
@@ -35,6 +36,35 @@ const previousAnnotationsReducer = (state = initialState, action) => {
 
       return Object.assign({}, state, {
         marks
+      });
+    
+    case REENABLE_PREVIOUS_ANNOTATION:
+      //Find the Previous (Aggregated) Annotation that matches the Selected Annotation, then reenable it.
+      const reenabledMarks = state.marks.map((item) => {
+        let isAMatch =  //First check: does the current Previous Annotation and the Selected Annotation look remotely similar?
+          item.hasCollaborated && item.points &&
+          action.selectedAnnotation && action.selectedAnnotation.points &&
+          item.points.length === action.selectedAnnotation.points.length;
+        
+        if (isAMatch) {  //Second check: do all the x-y coordinates that make the line match up?
+          item.points.map((a, index) => {
+            const b = action.selectedAnnotation.points[index];
+            isAMatch = isAMatch && a.x === b.x && a.y === b.y;
+          });
+        }
+        
+        //Finally, reenable the Previous Annotation if it's a match.
+        if (isAMatch) item.hasCollaborated = false;
+        
+        //WARNING: This is a fairly primitive method of reenabling the previous
+        //Annotation, and will not work if the user-created Annotation can have
+        //its x-y coordinates edited.
+        
+        return item;
+      });
+      
+      return Object.assign({}, state, {
+        marks: reenabledMarks,
       });
 
    default:
@@ -75,6 +105,19 @@ const updatePreviousAnnotation = (index) => {
   };
 };
 
+/*  When an Agreement Annotation (that was based on a Previous Annotation) is
+    deleted, attempt to re-enable that Previous Annotation.
+ */
+const reenablePreviousAnnotation = () => {
+  return (dispatch, getState) => {
+    const selectedAnnotation = getState().annotations.selectedAnnotation;
+    dispatch({
+      type: REENABLE_PREVIOUS_ANNOTATION,
+      selectedAnnotation,
+    });
+  };
+}
+
 const changeFrameData = (index) => {
   return (dispatch, getState) => {
     const data = getState().previousAnnotations.data;
@@ -114,5 +157,6 @@ export default previousAnnotationsReducer;
 export {
   changeFrameData,
   fetchAnnotations,
-  updatePreviousAnnotation
+  updatePreviousAnnotation,
+  reenablePreviousAnnotation,
 };


### PR DESCRIPTION
## PR Overview
- This PR adds the ability to delete an active (Selected) Annotation.
- The Delete button appears on the Text Input dialog that appears when a Selected Annotation is, well, selected. (Either upon clicking an existing Annotation that the user created, or after finishing the process of creating a new one. The Delete button does NOT appear on Aggregated (other people's) Annotations.
![screen shot 2017-10-16 at 19 10 01](https://user-images.githubusercontent.com/13952701/31627646-dfc80124-b2a5-11e7-802e-3e6bbe34f7cb.png)

### Issues to fix
- [x] When you create an Agreement Annotation from an Aggregated Annotation, and then delete said Agreement Annotation, the previous Aggregated Annotation doesn't re-appear. WHOOPSIEDOODLE.

### Thoughts/Possible improvements
- [x] Should clicking on "Delete" prompt a confirmation from the user... or what that be too damn annoying? I think the latter.
- [x] When creating a new Annotation, the Cancel button does _not_ delete the newly created Annotation. But should it? Think about it - user makes three dots, clicks the last one, then thinks "Oh, wait, that was wrong." Should "Cancel" when a line is newly created and has text === '' imply that the user meant to undo creating this line? Or am I worrying too much, since the Delete button does exactly what it needs to?
- [ ] That Delete button could use a visual upgrade. It's too innocuous and can be confused for a Done button. Solution: add icons? Colours?

### Status
WIP. When those checkboxes above are all ticked out, I'll submit this for a full review.