### PR TITLE
Reorder Annotations - User Annotations now above Previous Annotations

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -31,9 +31,9 @@ class AnnotationsPane extends React.Component {
     const imageOffset = `translate(${-this.props.imageSize.width/2}, ${-this.props.imageSize.height/2})`;
     return (
       <g transform={imageOffset}>
-        {this.renderAnnotationInProgress()}
-        {this.renderUserAnnotations()}
         {this.renderPreviousAnnotations()}
+        {this.renderUserAnnotations()}
+        {this.renderAnnotationInProgress()}
       </g>
     );
   }


### PR DESCRIPTION
## PR Overview
- This PR reorganises the order of the annotations so...
  - New (currently in progress) Annotations appear above...
  - User's (completed) Annottations, which appear above...
  - Previous (collaborative) Annotations.
- This is a _visual workaround_ that essentually fixes #97 .
  - The core of issue #97 is that when you Agree to a Previous Annotation on page 1, then switch to page 2 then back to page 1, the Previous Annotation now appears _overlaid on top of_ your Agreement Annotation.
  - This change essentially obscures the Previous Annotation behind the Agreement Annotation instead of simply not rendering the former.
  - Note: if this is the 'proper' solution going forward, it may also make the ("Reenable Previous Annotation"](https://github.com/zooniverse/liberating-the-liberator/pull/92/commits/8aa9ea56367b4c435deb336f971224f2957d9f03#diff-5815a1d65dcdd68154122cd603a23d9fR41) function introduced in commit 8aa9ea5 mildly redundant.

### Status
Ready for review, @wgranger 👍 