### PR TITLE
Adjust Fonts and Spacing Post-Design Review

### DIFF
--- a/src/components/AboutTheCollection.jsx
+++ b/src/components/AboutTheCollection.jsx
@@ -22,9 +22,9 @@ class AboutTheCollection extends React.Component {
               <Link to="/">Anti-Slavery Manuscripts</Link>
               <h3>About <i>the</i> Collection</h3>
               <span className="about-the-collection__content">
-                The Boston Public Library's Anti-Slavery collection-one of the largest
+                The Boston Public Library's Anti-Slavery collection &mdash; one of the largest
                 and most important collections of abolitionists material in the United
-                States-contains roughly 40,000 pieces of correspondence, broadsides,
+                States &mdash; contains roughly 40,000 pieces of correspondence, broadsides,
                 newspapers, pamphlets, books, and memorabilia from the 1830s through
                 the 1870s.
               </span><br />
@@ -51,7 +51,7 @@ class AboutTheCollection extends React.Component {
                   The extensive body of correspondence records interactions among
                   leading abolitionists in the United States and Great Britain over
                   a fifty year period, thus creating an archive that comprehensively
-                  documents the history of the 19-century anti-slavery movement in Boston
+                  documents the history of the 19th century anti-slavery movement in Boston
                   as well as abroad through the end of the American Civil War and the
                   abolition of slavery.
                 </div>
@@ -77,7 +77,7 @@ class AboutTheCollection extends React.Component {
           <div className="about-the-collection__attribution">
             <span className="about-the-collection__content">
               "Through the participation of citizen historians, we now stand on the
-              threshold of having available-free to all-the entire contents of the
+              threshold of having available &mdash; free to all &mdash; the entire contents of the
               Boston Public Library's extraordinary Anti-Slavery Manuscripts
               collection: the personal papers of women and men who joined together,
               across barriers of race and class, in the Abolitionist crusade."
@@ -119,9 +119,9 @@ class AboutTheCollection extends React.Component {
               <h2 className="about-the-collection__sub-head">Notable Figures</h2>
               <span className="about-the-collection__content">
                 Letters from and to leading representatives of the abolitionist
-                movement in the Boston area, most notable <i>Liberator</i> editor
+                movement in the Boston area &mdash; most notable <i>Liberator</i> editor
                 William Lloyd Garrison (1805-1879) and the Weston sisters of Weymouth,
-                Massachusetts, form the most significant component of the correspondence.
+                Massachusetts &mdash; form the most significant component of the correspondence.
               </span>
               <span className="about-the-collection__content">
                 Other major holdings include the papers of American abolitionists

--- a/src/components/AboutTheProject.jsx
+++ b/src/components/AboutTheProject.jsx
@@ -83,7 +83,7 @@ class AboutTheProject extends React.Component {
             the United States.
           </span>
           <span>
-            The collection includes a full run of William Lloyd Garrison's "The Liberator",
+            The collection includes a full run of William Lloyd Garrison's <i>The Liberator</i>,
             a newspaper that was published continuously for 35 years, from 1831 to 1866. This
             newspaper, published by Garrison, was the official organ of the abolitionist movement.
           </span>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -82,7 +82,7 @@ class Home extends React.Component {
             <b className="body-copy-first-word">Welcome</b> to Anti-Slavery Manuscripts.{' '}
             {this.props.project.description}
           </div>
-          <h3 className="transcribe">Transcribe Random&#8608;</h3>
+          <h3 className="transcribe">Transcribe Random &#8608;</h3>
           <span className="instructions">
             Click the button above to start with a random document, or choose a topic:
           </span>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -79,7 +79,7 @@ class Home extends React.Component {
           <h1 className="secondary-head">Presented <i className="secondary-conjunctions">by the</i> Boston Public Library</h1>
           <img role="presentation" className="divider" src={Divider} />
           <div className="home-page__body-text">
-            <b className="body-copy-first-word">Welcome</b> to Anti-Slavery Manuscripts.{' '}
+            <b className="body-copy-first-word">Welcome.</b>{' '}
             {this.props.project.description}
           </div>
           <h3 className="transcribe">Transcribe Random &#8608;</h3>

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -65,6 +65,7 @@ class ClassifierContainer extends React.Component {
 
   render() {
     const isAdmin = this.props.user && this.props.user.admin;
+    console.log('DONE AGAIN');
 
     return (
       <main className="app-content classifier-page flex-row">

--- a/src/lib/letter-groups.js
+++ b/src/lib/letter-groups.js
@@ -1,22 +1,22 @@
 const LetterGroups = [
   {
-    title: '1820-1840',
+    title: '1800-1839',
     workflow: '',
   },
   {
-    title: '1841-1850',
+    title: '1840-1849',
     workflow: '',
   },
   {
-    title: '1851-1860',
+    title: '1850-1859',
     workflow: '',
   },
   {
-    title: '1861-1870',
+    title: '1860-1869',
     workflow: '',
   },
   {
-    title: '1871-1900',
+    title: '1870-1900',
     workflow: '',
   }
 ];

--- a/src/lib/project-members.js
+++ b/src/lib/project-members.js
@@ -1,15 +1,18 @@
 const ProjectMembers = [
   {
-    photo: "Beth",
-    name: 'Beth Prindle',
+    photo: "Tom",
+    name: 'Tom Blake',
     description: `
-      Beth Prindle is Boston Public Library's Head of Special Collections,
-      overseeing the library's extensive holdings in rare books, manuscripts,
-      archives, prints, and fine arts. During her tenure at BPL, she has been
-      also been responsible for exhibitions, public programs, tours, and collections-related
-      special projects.  Beth started her career at BPL as the curator of the
-      John Adams Library, the 3,500-volume personal collection of President John
-      Adams. She is a former public high school teacher.
+      Tom Blake has been working at the Boston Public Library as their Digital
+      Imaging Production Manager and Digital Projects Manager since 2005. He
+      is currently responsible for the creation of beautiful, versatile, and
+      sustainable digital objects for all BPL digital initiatives. Since 2010,
+      he has managed an ambitious project to help digitize collections from across
+      Massachusetts in conjunction with Digital Commonwealth, a statewide repository
+      service, and as a pilot Service Hub of the Digital Public Library of America.
+      Tom has overseen the digitization of the BPL's anti-slavery manuscripts and
+      will be thrilled to see them transcribed so his kids who don't know cursive
+      can read them.
     `
   },
   {
@@ -41,19 +44,6 @@ const ProjectMembers = [
     `
   },
   {
-    photo: "Marilyn",
-    name: 'Marilyn Morgan',
-    description: `
-      Marilyn is the Director of the Archives Program and Lecturer in History at
-      UMass Boston. While earning a PhD in History, she became a passionate
-      educator in digital humanities, a seasoned archivist, and a champion of
-      open access and active outreach in archives and libraries. She's thrilled
-      to help expand access to BPL's archival collections on anti-slavery, and
-      believes that engaging the public will enrich digital history and contribute
-      to the transformation of education.
-    `
-  },
-  {
     photo: "Susan",
     name: 'Susan Mizruchi',
     description: `
@@ -69,19 +59,29 @@ const ProjectMembers = [
     `
   },
   {
-    photo: "Tom",
-    name: 'Tom Blake',
+    photo: "Marilyn",
+    name: 'Marilyn Morgan',
     description: `
-      Tom Blake has been working at the Boston Public Library as their Digital
-      Imaging Production Manager and Digital Projects Manager since 2005. He
-      is currently responsible for the creation of beautiful, versatile, and
-      sustainable digital objects for all BPL digital initiatives. Since 2010,
-      he has managed an ambitious project to help digitize collections from across
-      Massachusetts in conjunction with Digital Commonwealth, a statewide repository
-      service, and as a pilot Service Hub of the Digital Public Library of America.
-      Tom has overseen the digitization of the BPL's anti-slavery manuscripts and
-      will be thrilled to see them transcribed so his kids who don't know cursive
-      can read them.
+      Marilyn is the Director of the Archives Program and Lecturer in History at
+      UMass Boston. While earning a PhD in History, she became a passionate
+      educator in digital humanities, a seasoned archivist, and a champion of
+      open access and active outreach in archives and libraries. She's thrilled
+      to help expand access to BPL's archival collections on anti-slavery, and
+      believes that engaging the public will enrich digital history and contribute
+      to the transformation of education.
+    `
+  },
+  {
+    photo: "Beth",
+    name: 'Beth Prindle',
+    description: `
+      Beth Prindle is Boston Public Library's Head of Special Collections,
+      overseeing the library's extensive holdings in rare books, manuscripts,
+      archives, prints, and fine arts. During her tenure at BPL, she has been
+      also been responsible for exhibitions, public programs, tours, and collections-related
+      special projects.  Beth started her career at BPL as the curator of the
+      John Adams Library, the 3,500-volume personal collection of President John
+      Adams. She is a former public high school teacher.
     `
   }
 ];

--- a/src/styles/components/about-project.styl
+++ b/src/styles/components/about-project.styl
@@ -50,11 +50,12 @@
     padding: 2em 4em
 
     h3
-      @extend .body-copy
+      @extend .secondary-head
       font-size: 1.75em
       letter-spaceing: 0.2em
-      margin-bottom: 2em
+      margin-bottom: 0.6em
       text-align: center
+      text-transform: none
 
     @media(max-width: 750px)
       margin: 4em 2em
@@ -117,11 +118,12 @@
     padding: 2em
 
     h3
-      @extend .body-copy
+      @extend .secondary-head
       font-size: 1.35em
       line-height: 1.2em
       margin: 0
       text-align: center
+      text-transform: none
 
     h3:nth-child(2)
       font-style: italic

--- a/src/styles/components/app-layout.styl
+++ b/src/styles/components/app-layout.styl
@@ -11,7 +11,6 @@ main
 
 .project-background
   background-image: url('../images/main-bg.jpg')
-  background-size: cover
   bottom: 0
   left: 0
   right: 0

--- a/src/styles/components/classifier-page.styl
+++ b/src/styles/components/classifier-page.styl
@@ -60,7 +60,7 @@
       > .block
         display: flex
         flex-direction: row
-        letter-spacing: inherit
+        letter-spacing: 0.1em
         margin: 0.2rem 0
         padding: 0.5em
         text-align: left

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -12,8 +12,11 @@
   &__content
     display: flex
     flex-direction: column
-    padding: 0 2em 5em 2em
+    padding: 2.5em 2em 5em 2em
     text-align: center
+
+    .divider
+      margin: 3em auto
 
     h1
       word-wrap: break-word
@@ -25,7 +28,7 @@
     background: $light-eggplant
     display: flex
     flex-wrap: nowrap
-    height: 2em
+    height: 1.5em
     width: 100%
 
     .completed
@@ -40,12 +43,8 @@
 
   &__body-text
     @extend .body-copy
-    columns: 2
     margin: 0 22% 4em 22%
     text-align: left
-
-    @media(max-width: 500px)
-      columns: 1
 
   &__topic-select
     flex-wrap: wrap
@@ -183,6 +182,9 @@
     span
       margin: auto 0
 
+    .secondary-head
+      font-weight: 300
+
     div
       display: flex
       flex-direction: column
@@ -219,7 +221,7 @@
     color: $white
     display: flex
     flex-direction: column
-    padding: 2em 22%
+    padding: 4.5em 22%
     text-align: center
 
     .zooniverse-logo


### PR DESCRIPTION
Fixes #95 

This fixes some design suggestions based on a review of the landing and about the project page. Some content text is also changed in the about sections.

This PR also fixes the issue above, which was the result of `background-size: cover` when a popup was present.

Note: Footer suggestions should probably be done on the ZRC repo?

![asm-home-br](https://user-images.githubusercontent.com/14099077/31740742-d1886bd0-b417-11e7-9448-3870ff1cbdae.png)
![asm-transcribe-br](https://user-images.githubusercontent.com/14099077/31740751-d525d46c-b417-11e7-8bbc-66dd65063b7c.png)
![asm-aboutproject-br](https://user-images.githubusercontent.com/14099077/31742070-14c82b16-b41c-11e7-9f6f-105420f339f5.png)

