### PR TITLE
Functioning Text Modifiers

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -89,10 +89,16 @@ class SelectedAnnotation extends React.Component {
       }
     }
 
-    const regex1 = new RegExp("\[" + textTag + "\]\s*", "ig");
-    const regex2 = new RegExp("\s*\[\/" + textTag + "\]", "ig");
-    value.replace(regex1, `[${textTag}]`).replace(regex2, `[/${textTag}]`).replace(/\s+/g, ' ');
-    this.inputText.value = value;
+    const startReg = `(?=\\w*)\\[${textTag}\\]\\s*`;
+    const endReg = `\\s*\\[\\/${textTag}\\](?=\\w*)`;
+    const unclearReg = `(?=\\w*)\\[unclear\\](?=\\w*)`;
+
+    const padStart = new RegExp(startReg, 'ig');
+    const padEnd = new RegExp(endReg, 'ig');
+    const unclearPad = new RegExp(unclearReg, 'ig');
+
+    const paddedText = value.replace(padStart, ` [${textTag}]`).replace(padEnd, `[/${textTag}] `).replace(unclearPad, ' [unclear] ').replace(/\s+/g, ' ');
+    this.inputText.value = paddedText;
   }
 
   render() {

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -20,6 +20,7 @@ class SelectedAnnotation extends React.Component {
     this.toggleShowAnnotations = this.toggleShowAnnotations.bind(this);
     this.saveText = this.saveText.bind(this);
     this.deleteAnnotation = this.deleteAnnotation.bind(this);
+    this.markUnclear = this.markUnclear.bind(this);
 
     this.state = {
       annotationText: '',
@@ -57,6 +58,39 @@ class SelectedAnnotation extends React.Component {
 
   chooseAnnotationText(annotationText) {
     this.setState({ annotationText, showAnnotationOptions: false });
+  }
+
+  markUnclear(e) {
+    let textTag = 'unclear';
+    let value;
+    let textAfter;
+    let textInBetween;
+
+    const startTag = '[' + textTag + ']';
+    const endTag = '[/' + textTag + ']';
+    const text = this.inputText;
+    const textAreaValue = text.value;
+    const selectionStart = text.selectionStart;
+    const selectionEnd = text.selectionEnd;
+    const textBefore = textAreaValue.substring(0, selectionStart);
+    if (selectionStart === selectionEnd) {
+      textAfter = textAreaValue.substring(selectionStart, textAreaValue.length);
+      if (textTag === 'unclear') {
+        value = textBefore + startTag + textAfter;
+      } else {
+        value = textBefore + startTag + endTag + textAfter;
+      }
+    } else {
+      textInBetween = textAreaValue.substring(selectionStart, selectionEnd);
+      textAfter = textAreaValue.substring(selectionEnd, textAreaValue.length);
+      if (textTag === 'unclear') {
+        value = textBefore + startTag + textInBetween + textAfter;
+      } else {
+        value = textBefore + startTag + textInBetween + endTag + textAfter;
+      }
+    }
+
+    this.inputText.value = value;
   }
 
   render() {

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -89,6 +89,9 @@ class SelectedAnnotation extends React.Component {
       }
     }
 
+    const regex1 = new RegExp("\[" + textTag + "\]\s*", "ig");
+    const regex2 = new RegExp("\s*\[\/" + textTag + "\]", "ig");
+    value.replace(regex1, `[${textTag}]`).replace(regex2, `[/${textTag}]`).replace(/\s+/g, ' ');
     this.inputText.value = value;
   }
 

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -20,7 +20,7 @@ class SelectedAnnotation extends React.Component {
     this.toggleShowAnnotations = this.toggleShowAnnotations.bind(this);
     this.saveText = this.saveText.bind(this);
     this.deleteAnnotation = this.deleteAnnotation.bind(this);
-    this.markUnclear = this.markUnclear.bind(this);
+    this.textModifier = this.textModifier.bind(this);
 
     this.state = {
       annotationText: '',
@@ -60,8 +60,7 @@ class SelectedAnnotation extends React.Component {
     this.setState({ annotationText, showAnnotationOptions: false });
   }
 
-  markUnclear(e) {
-    let textTag = 'unclear';
+  textModifier(textTag) {
     let value;
     let textAfter;
     let textInBetween;

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -143,10 +143,10 @@ class SelectedAnnotation extends React.Component {
 
           <div className="selected-annotation__markup">
             <p>Text Modifiers</p>
-            <button>[insertion]</button>
-            <button>[deletion]</button>
-            <button>[unclear]</button>
-            <button>[underline]</button>
+            <button onClick={this.textModifier.bind(this, 'insertion')}>[insertion]</button>
+            <button onClick={this.textModifier.bind(this, 'deletion')}>[deletion]</button>
+            <button onClick={this.textModifier.bind(this, 'unclear')}>[unclear]</button>
+            <button onClick={this.textModifier.bind(this, 'underline')}>[underline]</button>
           </div>
 
           <p>


### PR DESCRIPTION
This PR contains basic functionality for text modifiers. I borrow code based on suggestions by @simensta. Everything appears to be working; however I still have a couple questions.

1) Basic UI - should we find a way to display this information when it comes back to a user from a previous annotation? ex. Would "This is [insertion]a test[/insertion]" rattle a user?

2) Should we write another bit of code to pad text correctly or trust a user to follow directions? ex. "Here is some [insertion] text I am [/insertion] writing" would throw off the reducer's word count.

Closes #65 