### PR TITLE
Fix Submit Classification bug

### DIFF
--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -106,23 +106,21 @@ const submitClassification = () => {
     const subject_dimensions = (subject && subject.imageMetadata) ? subject.imageMetadata : [];
     const classification = getState().classifications.classification;
     
-    if (classification) {
-      dispatch({ type: SUBMIT_CLASSIFICATION });
-      classification.annotations.push(annotations);
-      classification.update({
-        completed: true,
-        'metadata.finished_at': (new Date()).toISOString(),
-        'metadata.viewport': {
-          width: innerWidth,
-          height: innerHeight,
-        },
-        'metadata.subject_dimensions': subject_dimensions || [],
-      })
-      .save();
-    } else {
-      //TODO: Have better error handling.
-      alert('ERROR: Could not create Classification.');
-    }
+    //TODO: Better error handling
+    if (!classification) { alert('ERROR: Could not create Classification.'); return; }
+    
+    dispatch({ type: SUBMIT_CLASSIFICATION });
+    classification.annotations.push(annotations);
+    classification.update({
+      completed: true,
+      'metadata.finished_at': (new Date()).toISOString(),
+      'metadata.viewport': {
+        width: innerWidth,
+        height: innerHeight,
+      },
+      'metadata.subject_dimensions': subject_dimensions || [],
+    })
+    .save()
 
     //Successful save: reset everything, then get the next Subject.
     .then(() => {

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -106,18 +106,23 @@ const submitClassification = () => {
     const subject_dimensions = (subject && subject.imageMetadata) ? subject.imageMetadata : [];
     const classification = getState().classifications.classification;
     
-    dispatch({ type: SUBMIT_CLASSIFICATION });
-    classification.annotations.push(annotations);
-    classification.update({
-      completed: true,
-      'metadata.finished_at': (new Date()).toISOString(),
-      'metadata.viewport': {
-        width: innerWidth,
-        height: innerHeight,
-      },
-      'metadata.subject_dimensions': subject_dimensions || [],
-    })
-    .save()
+    if (classification) {
+      dispatch({ type: SUBMIT_CLASSIFICATION });
+      classification.annotations.push(annotations);
+      classification.update({
+        completed: true,
+        'metadata.finished_at': (new Date()).toISOString(),
+        'metadata.viewport': {
+          width: innerWidth,
+          height: innerHeight,
+        },
+        'metadata.subject_dimensions': subject_dimensions || [],
+      })
+      .save();
+    } else {
+      //TODO: Have better error handling.
+      alert('ERROR: Could not create Classification.');
+    }
 
     //Successful save: reset everything, then get the next Subject.
     .then(() => {

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -129,6 +129,7 @@ const submitClassification = () => {
       dispatch({ type: SUBMIT_CLASSIFICATION_SUCCESS });
       dispatch(resetAnnotations());
       dispatch(resetPreviousAnnotations());
+      dispatch(createClassification());
       dispatch(fetchSubject());
       dispatch(resetView());
     })


### PR DESCRIPTION
## PR Overview
Issue: when a user Submits a Classification (i.e. clicks Done), the next time they do so, they encounter an error.

Analysis:
- the createClassification() initialiser isn't properly called on all instances of a new Subject being loaded.
- See ClassifierContainer:
```
componentWillReceiveProps(nextProps) {
  if (nextProps.currentSubject && nextProps.workflow && !this.props.classification) {
    this.props.dispatch(createClassification());
  }
}
```

Solution:
- We force a createClassfication() call within the Submit Classification action itself.
- This may cause double work (since the componentWillReceiveProps seems rather random on when it creates a Classification) but it's a relatively safe method.

### WARNING
- While this PR fixes the Submit a Classification bug, it may expose a problem with the next set of Previous Annotations not being fetched.
- Unfortunately, I can't tell if the `fetchAnnotations()` function simply isn't called, or if it IS called but I'm getting a Subject with no Annotations.
- I'm waiting for some feedback on this.

### Status
Ready for review, @wgranger . Please take note of the Warning note above; I'd like to know what you see on your end.