### PR TITLE
Fix Safari's SVG image bug

### DIFF
--- a/src/components/SVGImage.jsx
+++ b/src/components/SVGImage.jsx
@@ -75,7 +75,7 @@ export default class SVGImage extends React.Component {
       return (
         <image className="svg-image"
           style={invertFilter}
-          href={this.image.src}
+          xlinkHref={this.image.src}
           width={this.image.width}
           height={this.image.height}
           x={(this.image.width * -0.5)+'px'}


### PR DESCRIPTION
## PR Overview
Issue: In Safari (OSX+Safari11) the `<image>` inside the `<svg>` doesn't show properly.

Analysis:
As it turns out, for Safari, the minimum needed for an inline SVG with an image is...
```
<svg>
  <image
    width="..." height="..."  //Required.
    xlink:href="image.png"   //Required. 'xlinkHref' in JSX. Previously, we were using 'href'.
  />
</svg>
```

Solution: In `SVGImage`, we replace `href` with `xlinkHref` (which translates to `xlink:href` in the actual HTML.)

### Dev Notes
Here's an example of some minimal SVG code that works in OSX+Chrome/FF/Safari and Win7+IE11 for future testing.

```
<!DOCTYPE html>
<html>
<head>
<title>Inline SVG Image Test</title>
</head>
<body>
  <h1>Inline SVG Image Test</h1>  
  <svg
    width="400"
    height="250"
    style="border: 1px solid #333"
  >
    <circle r="125" cx="200" cy="125" fill="#39c" />
    <image
      x="50"
      y="75"
      width="300"
      height="100"
      xlink:href="http://via.placeholder.com/300x100"
    />
  </svg>
</body>
</html>
```

### Status
Ready for review, @wgranger 