### PR TITLE
Streamline fetch lifecycle and fix fetching Subject from queue

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -9,6 +9,9 @@ import Header from './Header';
 import ProjectHeader from './ProjectHeader';
 import Dialog from './Dialog';
 
+import { PROJECT_STATUS } from '../ducks/project';
+import { WORKFLOW_STATUS } from '../ducks/workflow';
+
 class App extends React.Component {
   returnSomething(something) { // eslint-disable-line class-methods-use-this
     return something;
@@ -26,6 +29,11 @@ class App extends React.Component {
   }
 
   render() {
+    if (this.props.projectStatus !== PROJECT_STATUS.READY ||
+        this.props.workflowStatus !== WORKFLOW_STATUS.READY) {
+      return <div>Loading...</div>;
+    }  //TODO: Consider what to do for STATUS: ERROR
+    
     const path = this.props.location.pathname;
     const showTitle = path === '/classify';
 
@@ -51,24 +59,35 @@ class App extends React.Component {
 
 App.propTypes = {
   children: PropTypes.node,
-  dialog: PropTypes.node,
   dispatch: PropTypes.func,
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),
+  //--------
+  user: PropTypes.object,
+  dialog: PropTypes.node,
+  projectStatus: PropTypes.string,
+  workflowStatus: PropTypes.string,
 };
 
 App.defaultProps = {
   children: null,
   dialog: null,
   location: {},
+  //--------
+  user: null,
+  dialog: null,
+  projectStatus: PROJECT_STATUS.IDLE,
+  workflowStatus: WORKFLOW_STATUS.IDLE,
 };
 
 const mapStateToProps = (state) => {
   return {
+    user: state.login.user,
     dialog: state.dialog.data,
-    project: state.project,
-    user: state.login.user
+    //--------
+    projectStatus: state.project.status,
+    workflowStatus: state.workflow.status,
   };
 };
 

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -58,12 +58,6 @@ class ClassifierContainer extends React.Component {
 
   //----------------------------------------------------------------
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.currentSubject && nextProps.workflow && !this.props.classification) {
-      this.props.dispatch(createClassification());
-    }
-  }
-
   componentWillUnmount() {
     Split.clear();
   }

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -187,7 +187,7 @@ class SubjectViewer extends React.Component {
     //Make sure we monitor visible size of Subject Viewer.
     window.addEventListener('resize', this.updateSize);
     this.updateSize();
-    this.props.dispatch(fetchSubject());
+    this.props.dispatch(fetchSubject());  //Fetch the first subject.
   }
 
   componentWillReceiveProps(next) {

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -132,8 +132,7 @@ const submitClassification = () => {
       dispatch({ type: SUBMIT_CLASSIFICATION_SUCCESS });
       dispatch(resetAnnotations());
       dispatch(resetPreviousAnnotations());
-      dispatch(createClassification());
-      dispatch(fetchSubject());
+      dispatch(fetchSubject());  //Note: fetching a Subject will also create an empty Classification.
       dispatch(resetView());
     })
 

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -186,7 +186,7 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
           });
         
           //Once we have a Subject, create an empty Classification to go with it.
-          dispatch(createClassification(createClassification()));
+          dispatch(createClassification());
         })
         .catch(() => {
           dispatch({ type: FETCH_SUBJECT_ERROR });
@@ -206,7 +206,7 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
       });
       
       //Once we have a Subject, create an empty Classification to go with it.
-      dispatch(createClassification(createClassification()));
+      dispatch(createClassification());
     }
   };
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -9,6 +9,7 @@ project.
  */
 import apiClient from 'panoptes-client/lib/api-client.js';
 import { config, subjectSets } from '../config';
+import { createClassification } from './classifications';
 
 const FETCH_SUBJECT = 'FETCH_SUBJECT';
 const FETCH_SUBJECT_SUCCESS = 'FETCH_SUBJECT_SUCCESS';
@@ -176,7 +177,6 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
       apiClient.type('subjects/queued').get(subjectQuery)
         .then((queue) => {
           const currentSubject = queue.shift();
-
           dispatch({
             currentSubject,
             id: currentSubject.id,
@@ -184,6 +184,9 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
             type: FETCH_SUBJECT_SUCCESS,
             favorite: currentSubject.favorite || false,
           });
+        
+          //Once we have a Subject, create an empty Classification to go with it.
+          dispatch(createClassification(createClassification()));
         })
         .catch(() => {
           dispatch({ type: FETCH_SUBJECT_ERROR });
@@ -196,9 +199,14 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
       const currentSubject = getState().subject.queue.shift();
       dispatch({
         currentSubject,
+        id: currentSubject.id,
         queue: getState().subject.queue,
         type: FETCH_SUBJECT_SUCCESS,
+        favorite: currentSubject.favorite || false,
       });
+      
+      //Once we have a Subject, create an empty Classification to go with it.
+      dispatch(createClassification(createClassification()));
     }
   };
 };


### PR DESCRIPTION
## PR Overview
- This PR handles two major issues.
- First, the **fetching Subject-Classification lifecycle** has been refactored.
  - Instead of `createClassification()`  triggering inside `ClassifierContainer` as it waits for a new Subject to come in...
  - ... `createClassification()` is now triggered directly after a Subject is successfully fetched within its Duck. i.e., we're removing the 'React component monitoring for changes' bit.
- Second, this PR fixes an issue where you can't get the third Subject from your queue.

> Issue: after submitting the Classification for the second Subject in your queue, you can't load any more Subjects - the system crashes. 
> Analysis: In `fetchSubject()`, there's an if-else fork that either A. fetches a new Subject Queue and the latest Subject on that queue, or B. fetches the next Subject in an existing queue. Path B was set up in such a way that not all the necessary Subject information was passed to the reducer.
> Solution: fixed that.

@wgranger : Wait I just realised this, have we accounted for Subject Queues that are empty? i.e. no next subject?

This PR replace PR #113 which wasn't a good enough a fix, alas.

### Status
@wgranger Ready for review