### PR TITLE
Fix Subject queue not making sense

### DIFF
--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -55,7 +55,8 @@ const subjectReducer = (state = initialState, action) => {
 
     case SET_SUBJECT_SET:
       return Object.assign({}, state, {
-        subjectSet: action.id
+        subjectSet: action.id,
+        queue: [],
       });
 
     case FETCH_SUBJECT_ERROR:


### PR DESCRIPTION
## PR Overview
- There are two issues with the Panoptes `/queued` request for Subjects. (See Issue #125)
  - One: logged in vs non-logged in get very different queues.
  - Two: when we set a new Subject Set id, the existing queue isn't cleared, so the new Subject Set isn't actually requested.
- This PR fixes Issue TWO only, by resetting the internal queue whenever a new Subject ID is selected.

## Testing is Madness
TL;DR this is difficult to test, but it looks like it works to me.

Anyway. Testing this will be odd given that ASM has about 5 Subject Queues with only 1 Subject each, and given Issue One above. This is the only way I can tell that it works, on localhost, while not logged in: _(It always looks fine while logged in due to the combination of Issue 1 and the small Subject Sets.)_
1. As a non-logged in user, I always see the same Subject when I choose a Subject Set, e.g. "1800-1839". (Expected: since non-logged in users always receive the same queue in the same order (see Issue One), this means I should always get the same first subject in the ever-resetting queue. Prior to this PR: selecting a new Subject Set (e.g. from "1800-1839") from the home page over and over again has the weird effect of processing through the same queue, resulting in a parade of exact Subjects going on over and over again.).
2. As a non-logged in user, if I click Transcribe in the navi, then home, then Transcribe, then home, etc, I see the "processing through the same queue" mentioned above, which is (mostly) expected in this context.
3. As a logged in user, I notice no changes. (Expected - logged-in users only ever get Subject queues with one Subject since each Subject Set has only one Subject. Therefore, their queue is always fresh.)

### Status
Ready for review, @wgranger , but even if this is approved, it'll be worth monitoring this matter when we go into internal/beta testing and have larger Subject Sets to play with.