### PR TITLE
Annotation Logic Checks

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -64,6 +64,7 @@ class AnnotationsPane extends React.Component {
       if (i === this.props.annotationInProgress.points.length-1) {  //Final node: click to finish annotation.
         svgPoints.push(
           <circle
+            id="pulsating"
             key={svgPointPrefix+i}
             cx={point.x} cy={point.y} r={10} fill="#00CED1"
             className="end"
@@ -106,6 +107,15 @@ class AnnotationsPane extends React.Component {
 
     return (
       <g className="annotation-in-progress">
+        <animate
+          xlinkHref="#pulsating"
+          attributeType="CSS" attributeName="opacity"
+          from="1" to="0.2" dur="1s" begin="0s"
+          begin="pulsating.mouseout"
+          end="pulsating.mouseover"
+          repeatCount="indefinite"
+          fill="freeze"
+         />
         {svgLines}
         {svgPoints}
       </g>

--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { Utility } from '../lib/Utility';
 import { connect } from 'react-redux';
 import { VisibilitySplit } from 'seven-ten';
+import PendingAnnotation from './PendingAnnotation';
 
 class AnnotationsPane extends React.Component {
   constructor(props) {
@@ -28,9 +29,18 @@ class AnnotationsPane extends React.Component {
   //----------------------------------------------------------------
 
   render() {
+    const pendingLine = this.props.mouseInViewer && this.props.annotationInProgress !== null;
     const imageOffset = `translate(${-this.props.imageSize.width/2}, ${-this.props.imageSize.height/2})`;
     return (
       <g transform={imageOffset}>
+        {pendingLine && (
+          <PendingAnnotation
+            angleDegree={this.props.angleDegree}
+            annotationInProgress={this.props.annotationInProgress}
+            getPointerXY={this.props.getPointerXY}
+            mouseInViewer={this.props.mouseInViewer}
+          />
+        )}
         {this.renderPreviousAnnotations()}
         {this.renderUserAnnotations()}
         {this.renderAnnotationInProgress()}
@@ -232,6 +242,7 @@ AnnotationsPane.propTypes = {
   }),
   //--------
   adminOverride: PropTypes.bool,
+  angleDegree: PropTypes.func,
   annotationInProgress: PropTypes.shape({
     text: PropTypes.string,
     points: PropTypes.arrayOf(PropTypes.shape({

--- a/src/components/PendingAnnotation.jsx
+++ b/src/components/PendingAnnotation.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Utility } from '../lib/Utility';
+
+class PendingAnnotation extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleMouseMove = this.handleMouseMove.bind(this);
+
+    this.state = {
+      pointer: null
+    }
+  }
+
+  componentWillMount() {
+    document.addEventListener('mousemove', this.handleMouseMove);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousemove', this.handleMouseMove);
+  }
+
+  handleMouseMove(e) {
+    if (this.props.mouseInViewer && this.props.getPointerXY && this.props.annotationInProgress) {
+      const pointer = this.props.getPointerXY(e);
+      this.setState({ pointer });
+    }
+  }
+
+  /*  Renders the annotation that the user is currently making, if there is one.
+   */
+  render() {
+    if (!this.props.annotationInProgress) return null;
+    let pendingPoint = null;
+    let pendingLine = null;
+    const i = this.props.annotationInProgress.points.length;
+
+    const point = this.props.annotationInProgress.points[i];
+    let fill = "#00CED1";
+
+    if (this.state.pointer) {
+      const prevPoint = this.props.annotationInProgress.points[i - 1];
+      const beforePoint = this.props.annotationInProgress.points[i - 2];
+      if (i >= 2) {
+        const straight = this.props.angleDegree(this.state.pointer, prevPoint, beforePoint);
+        if (!straight) fill = "#c33";
+      }
+      pendingPoint = (
+        <circle
+          key="PENDING_POINT"
+          fillOpacity="0.4"
+          cx={this.state.pointer.x} cy={this.state.pointer.y} r={10} fill={fill}
+        />
+      )
+      pendingLine = (
+        <line
+          key="PENDING_LINE"
+          fillOpacity="0.4"
+          x1={prevPoint.x} y1={prevPoint.y}
+          x2={this.state.pointer.x} y2={this.state.pointer.y}
+          stroke={fill} strokeWidth="2"
+        />
+      )
+    }
+
+    return (
+      <g className="annotation-in-progress" pointerEvents="none">
+        {pendingPoint}
+        {pendingLine}
+      </g>
+    );
+  }
+}
+
+PendingAnnotation.propTypes = {
+  angleDegree: PropTypes.func,
+  annotationInProgress: PropTypes.shape({
+    text: PropTypes.string,
+    points: PropTypes.arrayOf(PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+    })),
+  }),
+  getPointerXY: PropTypes.func,
+  mouseInViewer: PropTypes.bool,
+};
+
+PendingAnnotation.defaultProps = {
+  angleDegree: () => {},
+  annotationInProgress: null,
+  getPointerXY: () => {},
+  mouseInViewer: false,
+};
+
+export default PendingAnnotation;

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -22,9 +22,11 @@ class SelectedAnnotation extends React.Component {
     this.deleteAnnotation = this.deleteAnnotation.bind(this);
     this.textModifier = this.textModifier.bind(this);
     this.cancelAnnotation = this.cancelAnnotation.bind(this);
+    this.renderWordCount = this.renderWordCount.bind(this);
 
     this.state = {
       annotationText: '',
+      disableSubmit: true,
       previousTranscriptionAgreement: false,
       previousTranscriptionSelection: false,
       showAnnotationOptions: false
@@ -188,8 +190,12 @@ class SelectedAnnotation extends React.Component {
             this.renderAnnotationOptions()
           )}
 
+          {!this.state.showAnnotationOptions && (
+            this.renderWordCount()
+          )}
+
           <div className="selected-annotation__buttons">
-            <button className="done-button" onClick={this.saveText}>Done</button>
+            <button className="done-button" disabled={this.state.disableSubmit} onClick={this.saveText}>Done</button>
             <button onClick={this.cancelAnnotation}>Cancel</button>
             {(this.props.annotation.previousAnnotation) ? null :
               <button onClick={this.deleteAnnotation}>Delete</button>
@@ -219,6 +225,21 @@ class SelectedAnnotation extends React.Component {
           );
         })}
       </div>
+    )
+  }
+
+  renderWordCount() {
+    const expectedWords = this.props.selectedAnnotation.points.length - 1;
+    const text = this.inputText ? this.inputText.value : "";
+    const cleaned_text = text.replace(/\s+/g, ' ').trim();
+    const number_of_words = cleaned_text ? cleaned_text.split(' ').length : 0;
+    const style = expectedWords === number_of_words ? "selected-annotation--green" : "selected-annotation--red";
+
+    return (
+      <span className={style}>
+        {number_of_words} of {expectedWords} words typed.
+        Your word count must match the number of dots minus one.
+      </span>
     )
   }
 
@@ -258,6 +279,21 @@ class SelectedAnnotation extends React.Component {
       annotationText: this.inputText.value,
       previousTranscriptionAgreement: false,
     });
+
+    this.wordCount(this.inputText.value);
+  }
+
+  wordCount(text) {
+    const cleaned_text = text.replace(/\s+/g, ' ').trim();
+    const number_of_words = cleaned_text.split(' ').length;
+    const dots = this.props.selectedAnnotation.points.length;
+    const correctLength = number_of_words === dots - 1;
+    if (correctLength) {
+      this.setState({ disableSubmit: false });
+    }
+    else if (!this.state.disableSubmit && !correctLength) {
+      this.setState({ disableSubmit: true });
+    }
   }
 }
 

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -76,7 +76,6 @@ class SelectedAnnotation extends React.Component {
       showAnnotationOptions: false
     });
 
-    this.wordCount(annotationText);
     if (this.inputText) this.inputText.value = annotationText;
 
   }
@@ -149,6 +148,8 @@ class SelectedAnnotation extends React.Component {
       y: inputY + BUFFER,
       width: PANE_WIDTH,
     };
+    
+    const wordCountMatchesDots = this.doesWordCountMatchDots(this.state.annotationText, this.props.selectedAnnotation.points.length);
 
     return (
       <Rnd
@@ -195,11 +196,11 @@ class SelectedAnnotation extends React.Component {
           )}
 
           {!this.state.showAnnotationOptions && (
-            this.renderWordCount()
+            this.renderWordCount(this.state.annotationText)
           )}
 
           <div className="selected-annotation__buttons">
-            <button className="done-button" disabled={this.state.disableSubmit} onClick={this.saveText}>Done</button>
+            <button className="done-button" disabled={!wordCountMatchesDots} onClick={this.saveText}>Done</button>
             <button onClick={this.cancelAnnotation}>Cancel</button>
             {(this.props.annotation.previousAnnotation) ? null :
               <button onClick={this.deleteAnnotation}>Delete</button>
@@ -232,9 +233,8 @@ class SelectedAnnotation extends React.Component {
     )
   }
 
-  renderWordCount() {
+  renderWordCount(text) {
     const expectedWords = this.props.selectedAnnotation.points.length - 1;
-    const text = this.inputText ? this.inputText.value : "";
     const cleaned_text = text.replace(/\s+/g, ' ').trim();
     const number_of_words = cleaned_text ? cleaned_text.split(' ').length : 0;
     const style = expectedWords === number_of_words ? "selected-annotation--green" : "selected-annotation--red";
@@ -245,6 +245,12 @@ class SelectedAnnotation extends React.Component {
         Your word count must match the number of dots minus one.
       </span>
     )
+  }
+  
+  doesWordCountMatchDots(text, dots) {
+    const cleaned_text = text.replace(/\s+/g, ' ').trim();
+    const number_of_words = cleaned_text.split(' ').length;
+    return number_of_words === dots - 1;
   }
 
   saveText() {
@@ -283,21 +289,6 @@ class SelectedAnnotation extends React.Component {
       annotationText: this.inputText.value,
       previousTranscriptionAgreement: false,
     });
-
-    this.wordCount(this.inputText.value);
-  }
-
-  wordCount(text) {
-    const cleaned_text = text.replace(/\s+/g, ' ').trim();
-    const number_of_words = cleaned_text.split(' ').length;
-    const dots = this.props.selectedAnnotation.points.length;
-    const correctLength = number_of_words === dots - 1;
-    if (correctLength) {
-      this.setState({ disableSubmit: false });
-    }
-    else if (!this.state.disableSubmit && !correctLength) {
-      this.setState({ disableSubmit: true });
-    }
   }
 }
 

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -76,6 +76,7 @@ class SelectedAnnotation extends React.Component {
       showAnnotationOptions: false
     });
 
+    this.wordCount(annotationText);
     if (this.inputText) this.inputText.value = annotationText;
 
   }

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -26,7 +26,6 @@ class SelectedAnnotation extends React.Component {
 
     this.state = {
       annotationText: '',
-      disableSubmit: true,
       previousTranscriptionAgreement: false,
       previousTranscriptionSelection: false,
       showAnnotationOptions: false

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -75,6 +75,9 @@ class SelectedAnnotation extends React.Component {
       previousTranscriptionSelection: true,
       showAnnotationOptions: false
     });
+
+    if (this.inputText) this.inputText.value = annotationText;
+
   }
 
   textModifier(textTag) {

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -48,6 +48,7 @@ const INPUT_STATE = {
 }
 
 const ZOOM_STEP = 0.1;
+const MAX_ANGLE = 5;
 
 //Add ?dev=1 to the URL to enable DEV_MODE
 const DEV_MODE = window.location && /(\?|&)dev(=|&|$)/ig.test(window.location.search);
@@ -67,6 +68,7 @@ class SubjectViewer extends React.Component {
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
+    this.onMouseEnter = this.onMouseEnter.bind(this);
     this.onMouseLeave = this.onMouseLeave.bind(this);
     this.useZoomIn = this.useZoomIn.bind(this);
     this.useZoomOut = this.useZoomOut.bind(this);
@@ -93,6 +95,7 @@ class SubjectViewer extends React.Component {
     //State
     this.state = {
       annotation: null,
+      mouseInViewer: false,
       pointerXYOnImage: null,
     };
   }
@@ -116,6 +119,7 @@ class SubjectViewer extends React.Component {
         <svg
           ref={(c)=>{this.svg=c}}
           viewBox="0 0 100 100"
+          onMouseEnter={this.onMouseEnter}
           onMouseDown={this.onMouseDown}
           onMouseUp={this.onMouseUp}
           onMouseMove={this.onMouseMove}
@@ -134,7 +138,10 @@ class SubjectViewer extends React.Component {
               imageSize={this.props.imageSize}
               annotationInProgress={this.props.annotationInProgress}
               annotations={this.props.annotations}
+              angleDegree={this.angleDegree}
               frame={this.props.frame}
+              getPointerXY={this.getPointerXYOnImage}
+              mouseInViewer={this.state.mouseInViewer}
               onCompleteAnnotation={this.onCompleteAnnotation}
               onSelectAnnotation={this.onSelectAnnotation}
               previousAnnotations={this.props.previousAnnotations}
@@ -297,6 +304,13 @@ class SubjectViewer extends React.Component {
       return Utility.stopEvent(e);
     } else if (this.props.viewerState === SUBJECTVIEWER_STATE.ANNOTATING) {
       const pointerXYOnImage = this.getPointerXYOnImage(e);
+      if (this.props.annotationInProgress && this.props.annotationInProgress.points.length >= 2) {
+        const i = this.props.annotationInProgress.points.length - 1;
+        const points = this.props.annotationInProgress.points;
+
+        const straight = this.angleDegree(pointerXYOnImage, points[i], points[i - 1]);
+        if (!straight) return Utility.stopEvent(e);
+      }
       this.props.dispatch(addAnnotationPoint(pointerXYOnImage.x, pointerXYOnImage.y, this.props.frame));
     }
   }
@@ -320,10 +334,25 @@ class SubjectViewer extends React.Component {
   }
 
   onMouseLeave(e) {
+    this.setState({ mouseInViewer: false });
     if (this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING) {
       this.pointer.state = INPUT_STATE.IDLE;
       return Utility.stopEvent(e);
     }
+  }
+
+  onMouseEnter(e) {
+    this.setState({ mouseInViewer: true });
+    return Utility.stopEvent(e);
+  }
+
+  angleDegree(A,B,C) {
+    const AB = Math.sqrt(Math.pow(B.x-A.x,2)+ Math.pow(B.y-A.y,2));
+    const BC = Math.sqrt(Math.pow(B.x-C.x,2)+ Math.pow(B.y-C.y,2));
+    const AC = Math.sqrt(Math.pow(C.x-A.x,2)+ Math.pow(C.y-A.y,2));
+    const radians = Math.acos((BC*BC+AB*AB-AC*AC)/(2*BC*AB));
+    const degrees = radians * 180 / Math.PI;
+    return (180 - degrees) <= MAX_ANGLE;
   }
 
   /*  Triggers when the user clicks on the final node/point of an

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -48,7 +48,7 @@ const INPUT_STATE = {
 }
 
 const ZOOM_STEP = 0.1;
-const MAX_ANGLE = 5;
+const MAX_ANGLE = 8;
 
 //Add ?dev=1 to the URL to enable DEV_MODE
 const DEV_MODE = window.location && /(\?|&)dev(=|&|$)/ig.test(window.location.search);
@@ -330,6 +330,10 @@ class SubjectViewer extends React.Component {
         ));
       }
       return Utility.stopEvent(e);
+    }
+
+    if (!this.state.mouseInViewer) {
+      this.setState({ mouseInViewer: true });
     }
   }
 

--- a/src/styles/components/selected-annotation.styl
+++ b/src/styles/components/selected-annotation.styl
@@ -17,6 +17,12 @@
   overflow: hidden
   padding: 1em
 
+  &--red
+    color: $warning
+
+  &--green
+    color: $success
+
   h2
     letter-spacing: 0.06em
 
@@ -93,6 +99,10 @@
 
   &__buttons .done-button
     background-color: $aqua-marine
+
+    &:disabled
+      background-color: $light-grey
+      cursor: default
 
 .close-button
   background: transparent

--- a/src/styles/global/app-theme.styl
+++ b/src/styles/global/app-theme.styl
@@ -11,6 +11,7 @@ $forest-green = #2EA08D
 $baby-blue = #8acff0
 $sandy = #F4F0E7
 $success = #5cb85c
+$warning = #cc0000
 
 $black = #111
 $white = #fff


### PR DESCRIPTION
This PR contains three main logic checks:

1) Disable the "done" button on the `SelectedAnnotation` pane until the correct amount of words have been typed.
2) Disallow a user to create an annotation point unless the points are in a line.
3) Pulsate the most recent annotation point as a signifier that it can be clicked to end an annotation.

*Note: The second item was done with a separate component to keep the entire `AnnotationPane` from updating when `setState` was called with a mouse move. Also, I'm open to ideas on the third item as I know SVG animations are not supported by all browsers, and this was the first solution I arrived upon.

Closes #75 