### PR TITLE
Change workflow ID for production

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,7 +36,7 @@ const baseConfig = {
       host: 'https://www.zooniverse.org/',
       projectId: '4973',
       projectSlug: 'bostonpubliclibrary/anti-slavery-manuscripts',
-      workflowId: '5219'
+      workflowId: '5329'
     },
   }
 };


### PR DESCRIPTION
## PR Overview
- This PR changes the ID for the production workflow.
- Following the conversation on Slack, the new production workflow (5329) was created to much better copy the structure set up by the staging workflow (3017).
- The `grouped: true` attribute of the workflow had to be set separately, via the zooAPI dev tool.

### Status
Minor change; I'll take responsibility for merging this.